### PR TITLE
Change F107_KP_SIZE and F107_KP_SKIP_SIZE in compsets to extend max l…

### DIFF
--- a/RT_WAM/solar_in
+++ b/RT_WAM/solar_in
@@ -3,7 +3,7 @@
  solar_file = 'wam_nems_feuv_2012.nc'
  Dir_swpc = './'
  Dir_uid =  './'
- f107_fix = 70., f107d_fix=70.,  kp_fix=1., ap_fix = 3.
+ f107_fix = 120., f107a_fix=120.,  kp_fix=1., ap_fix = 3.
  noeof_file='./snoe_eof.nc'
  wxdan_file='./wasolar_dan_20161019.nc'
  wam2012_file='./wam_nems_feuv_2012_366d_by_24hr.nc'

--- a/oldcompsets/swpc%20130316_1hr_spacewx_gsm%wam%T62_ipe%80x170
+++ b/oldcompsets/swpc%20130316_1hr_spacewx_gsm%wam%T62_ipe%80x170
@@ -39,11 +39,11 @@ export med_petlist_bounds="32 39" # 8
 export coupling_interval_fast_sec=180.0
 export coupling_interval_sec=180.0
 
-export F107_KP_SIZE=56
+export F107_KP_SIZE=4800 # 600 days
 export F107_KP_INTERVAL=10800
 export WAM_IPE_COUPLING=.true.
 export HEIGHT_DEPENDENT_G=.true.
-export F107_KP_SKIP_SIZE=24
+export F107_KP_SKIP_SIZE=0
 
 # Set restart directory
 export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/

--- a/oldcompsets/swpc%20130316_1hr_spacewx_gsm%wam%T62_ipe%80x170_restart
+++ b/oldcompsets/swpc%20130316_1hr_spacewx_gsm%wam%T62_ipe%80x170_restart
@@ -40,11 +40,11 @@ export med_petlist_bounds="32 39" # 8
 export coupling_interval_fast_sec=180.0
 export coupling_interval_sec=180.0
 
-export F107_KP_SIZE=56
+export F107_KP_SIZE=4800 # 600 days
 export F107_KP_INTERVAL=10800
 export WAM_IPE_COUPLING=.true.
 export HEIGHT_DEPENDENT_G=.true.
-export F107_KP_SKIP_SIZE=24
+export F107_KP_SKIP_SIZE=0
 
 export fcst_begin=.false.
 export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/

--- a/oldcompsets/swpc%20130316_2day_spacewx_gsm%wam%T62_ipe%80x170
+++ b/oldcompsets/swpc%20130316_2day_spacewx_gsm%wam%T62_ipe%80x170
@@ -39,11 +39,11 @@ export ipm_petlist_bounds="24 103"  # 80
 export coupling_interval_fast_sec=180.0
 export coupling_interval_sec=180.0
 
-export F107_KP_SIZE=56
+export F107_KP_SIZE=4800 # 600 days
 export F107_KP_INTERVAL=10800
 export WAM_IPE_COUPLING=.true.
 export HEIGHT_DEPENDENT_G=.true.
-export F107_KP_SKIP_SIZE=24
+export F107_KP_SKIP_SIZE=0
 
 # Set restart directory
 export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/

--- a/oldcompsets/swpc%20130316_2day_spacewx_gsm%wam%T62_ipe%80x170_restart
+++ b/oldcompsets/swpc%20130316_2day_spacewx_gsm%wam%T62_ipe%80x170_restart
@@ -39,11 +39,11 @@ export ipm_petlist_bounds="24 103"  # 80
 export coupling_interval_fast_sec=180.0
 export coupling_interval_sec=180.0
 
-export F107_KP_SIZE=56
+export F107_KP_SIZE=4800 # 600 days
 export F107_KP_INTERVAL=10800
 export WAM_IPE_COUPLING=.true.
 export HEIGHT_DEPENDENT_G=.true.
-export F107_KP_SKIP_SIZE=24
+export F107_KP_SKIP_SIZE=0
 
 export fcst_begin=.false.
 export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/

--- a/oldcompsets/swpc%20130316_5day_spacewx_gsm%wam%T62_ipe%80x170
+++ b/oldcompsets/swpc%20130316_5day_spacewx_gsm%wam%T62_ipe%80x170
@@ -39,12 +39,11 @@ export ipm_petlist_bounds="24 103"  # 80
 export coupling_interval_fast_sec=180.0
 export coupling_interval_sec=180.0
 
-export F107_KP_SIZE=56
+export F107_KP_SIZE=4800 # 600 days
 export F107_KP_INTERVAL=10800
 export WAM_IPE_COUPLING=.true.
 export HEIGHT_DEPENDENT_G=.true.
-export F107_KP_SKIP_SIZE=24
-
+export F107_KP_SKIP_SIZE=0
 
 # Set restart directory
 export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/

--- a/oldcompsets/swpc%20130316_5day_spacewx_gsm%wam%T62_ipe%80x170_restart
+++ b/oldcompsets/swpc%20130316_5day_spacewx_gsm%wam%T62_ipe%80x170_restart
@@ -39,11 +39,11 @@ export ipm_petlist_bounds="24 103"  # 80
 export coupling_interval_fast_sec=180.0
 export coupling_interval_sec=180.0
 
-export F107_KP_SIZE=56
+export F107_KP_SIZE=4800 # 600 days
 export F107_KP_INTERVAL=10800
 export WAM_IPE_COUPLING=.true.
 export HEIGHT_DEPENDENT_G=.true.
-export F107_KP_SKIP_SIZE=24
+export F107_KP_SKIP_SIZE=0
 
 export fcst_begin=.false.
 export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/

--- a/oldcompsets/swpc%20130316_6day_spacewx_gsm%wam%T62_ipe%80x170
+++ b/oldcompsets/swpc%20130316_6day_spacewx_gsm%wam%T62_ipe%80x170
@@ -39,11 +39,11 @@ export ipm_petlist_bounds="24 103"  # 80
 export coupling_interval_fast_sec=180.0
 export coupling_interval_sec=180.0
 
-export F107_KP_SIZE=56
+export F107_KP_SIZE=4800 # 600 days
 export F107_KP_INTERVAL=10800
 export WAM_IPE_COUPLING=.true.
 export HEIGHT_DEPENDENT_G=.true.
-export F107_KP_SKIP_SIZE=24
+export F107_KP_SKIP_SIZE=0
 
 # Set restart directory
 export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/


### PR DESCRIPTION
…ength of a WAM run from 7 days to longer than we think we'll ever run (600 days). Also, fix known bug with varible name (f107a_fix) in solar_in