### PR TITLE
changes to make WAM-IPE build on NASA's Pleiades

### DIFF
--- a/IPELIB/src/Makefile
+++ b/IPELIB/src/Makefile
@@ -27,12 +27,13 @@ TARGETS = clean                   \
           trillian_pgi_parallel   \
           trillian_pgi_serial     \
           theia_intel_parallel    \
-          theia_intel_serial \
-          wcoss_intel_parallel \
-          wcoss_intel_serial \
-          generic_pgi_serial \
-          generic_gnu_serial \
-          generic_intel_serial
+          theia_intel_serial      \
+          wcoss_intel_parallel    \
+          wcoss_intel_serial      \
+          generic_pgi_serial      \
+          generic_gnu_serial      \
+          generic_intel_serial    \
+          pleiades_intel_parallel
 
 # Dynamic / Conditional variables
 
@@ -201,6 +202,17 @@ endif
   endif
 endif
 
+# pleiades stanza
+ifeq ($(MACHINE),pleiades)
+  GPTL_USE_GPTL = no
+  MAKEJOBS = 1
+  MODCMD = . /usr/local/lib/init/global.profile && module purge && module load comp-intel mpi-sgi/mpt
+  FCP = ifort -lmpi
+  FCS = ifort
+  OPT_FLAGS = -O3 -fp-model precise -fpp
+  SMS = /nobackupp8/akubaryk/save/sms/SMSr825-intel
+endif
+
 # These statements are machine/compiler independent
 ifeq ($(TESTING),yes)
   OPT_FLAGS+= -DTESTING
@@ -303,6 +315,13 @@ ifeq ($(TESTING),yes)
 	make --directory=integration_testing/ -f cmdi.mak clean
 endif
 	$(MAKE) ipe MACHINE=generic COMPILER=intel PARALLELISM=serial
+
+pleiades_intel_parallel:
+ifeq ($(TESTING),yes)
+	$(MAKE) cmdi MACHINE=pleiades COMPILER=intel PARALLELISM=parallel
+	make --directory=integration_testing/ -f cmdi.mak clean
+endif
+	$(MAKE) ipe MACHINE=pleiades COMPILER=intel PARALLELISM=parallel
 
 ipe:
 	$(if $(filter 0,$(MAKELEVEL)),$(call USAGE))

--- a/NEMS/NEMSAppBuilder
+++ b/NEMS/NEMSAppBuilder
@@ -14,16 +14,12 @@ global_name='NEMSAppBuilder'
 global_version='version 1.1.0'
 global_capabilities='autobuild dialog whiptail FV3 HYCOM MOM5 CICE IPE WRFHYDRO WW3 LIS IMP GSM NMMB KISS NOAH NOAHMP LegacyGSM LegacyNMM'
 
-# determine whether dialog or whiptail is available
-read dialog <<< "$(which dialog 2> /dev/null)"
-read whiptail <<< "$(which whiptail 2> /dev/null)"
-
-# use whichever tool was found
+# use whichever tool we can find (dialog or whiplash)
 if [[ "$#" -gt 0 ]] ; then
   tool=autobuild
   toolflag=autobuild
-elif [ -n $dialog ] ; then
-  tool=$dialog
+elif type "dialog" > /dev/null 2>&1; then
+  tool=`which dialog`
   toolflag="dialog"
   if [[ "$tool" =~ "scratch4/NCEPDEV/nems/save/Gerhard.Theurich/bin" ]]; then
     # Special Theia case here of avoiding branches below that spawn multiple 
@@ -31,8 +27,8 @@ elif [ -n $dialog ] ; then
     # for some reason!
     toolflag="NOTdialog"
   fi
-elif [ -n $whiptail ] ; then
-  tool=$whiptail
+elif type "whiptail" > /dev/null 2>&1; then
+  tool=`which whiptail`
   toolflag="whiptail"
 else
   echo "ABORT: Neither dialog nor whiptail found." 1>&2
@@ -1096,6 +1092,7 @@ if [[ $appCounter != 1 && "$tool" != autobuild ]]; then
   bailFlag=true
   while [ $bailFlag == "true" ] ; do
   bailFlag=false
+  echo $tool
   "$tool" --clear --backtitle "NEMS Application Builder" \
     --title "Welcome" --msgbox "Welcome to the NOAA Environmental Modeling System (NEMS) \
 Application Builder. \

--- a/NEMS/NEMSAppBuilder
+++ b/NEMS/NEMSAppBuilder
@@ -22,7 +22,7 @@ read whiptail <<< "$(which whiptail 2> /dev/null)"
 if [[ "$#" -gt 0 ]] ; then
   tool=autobuild
   toolflag=autobuild
-elif ["${dialog}x" != "x" ] ; then
+elif [ -n $dialog ] ; then
   tool=$dialog
   toolflag="dialog"
   if [[ "$tool" =~ "scratch4/NCEPDEV/nems/save/Gerhard.Theurich/bin" ]]; then
@@ -31,7 +31,7 @@ elif ["${dialog}x" != "x" ] ; then
     # for some reason!
     toolflag="NOTdialog"
   fi
-elif [ "${whiptail}x" != "x" ] ; then
+elif [ -n $whiptail ] ; then
   tool=$whiptail
   toolflag="whiptail"
 else
@@ -78,9 +78,11 @@ elif [[ -e /pan2 && -e /lfs3 ]] ; then
     FULL_MACHINE_ID=jet
     MACHINE_ID=jet
 elif ( hostname | grep -i gaea ) ; then
-    # Default to GAEA until we add more platforms
     FULL_MACHINE_ID=gaea
     MACHINE_ID=gaea
+elif [[ -e /nobackupp8 ]] ; then
+    FULL_MACHINE_ID=pleiades
+    MACHINE_ID=pleiades
 else
     # Unknown platform
     FULL_MACHINE_ID=unknown
@@ -561,11 +563,11 @@ build_checkloop(){
       while read line
       do
         procline=`echo $line | grep -v "\.mk"`  # exclude .mk from comparing
-        if [ "x$procline" != "x" ]; then
+        if [ -n $procline ]; then
           # valid line
           checksum=`echo $procline | awk ' { print $1 } '`
           check=`grep $checksum $COMP.install.md5sum.$MACHINE_ID.tmp`
-          if [ "x$check" == "x" ]; then
+          if [ -z $check ]; then
             # did not find the checksum -> failed check
             reuse=false_failchecksum
           fi
@@ -817,7 +819,7 @@ build_cice(){
     export SYSTEM_USERDIR=`pwd`
     export SRCDIR=`pwd`
     export EXEDIR=`pwd`
-    if [ "${NEMS_GRID}x" != "x" ] ; then
+    if [ -n $NEMS_GRID ]; then
       export NEMS_GRID="$NEMS_GRID"
     else
       export NEMS_GRID=T126_mx5
@@ -913,6 +915,9 @@ build_ipe(){
     elif [[ $MACHINE_ID == wcoss ]] ; then
        export SMS=/gpfs/hps/emc/global/save/Adam.Kubaryk/sms/SMSr825-intel_O3
        make wcoss_intel_parallel
+    elif [[ $MACHINE_ID == pleiades ]] ; then
+       export SMS=/nobackupp8/akubaryk/save/sms/SMSr825-intel
+       make pleiades_intel_parallel
     else
        echo "Machine not currently supported in NEMSAppBuilder."
        exit
@@ -1049,7 +1054,7 @@ shopt -s nullglob # all expansion to null string
 defaultSelect=NULL
 highestPriority=0
 for i in "$ROOTDIR"/*.appBuilder; do
-   if [ "x$i" != "x" ]; then
+   if [ -n $i ]; then
       sortingPriority=0
       prioline=$( grep sortingPriority "$i" | head -1 )
       eval $prioline
@@ -1063,7 +1068,7 @@ for i in "$ROOTDIR"/*.appBuilder; do
 done
 
 for i in "$ROOTDIR"/*.appBuilder; do
-  if [ "x$i" != "x" ]; then
+  if [ -n $i ]; then
     let appCounter++
     title=`head -1 $i`
     title=${title#"#"}
@@ -1116,7 +1121,7 @@ if [ $appCounter == 0 ]; then
   appCounter=1
   # check the AppBuilder subdirectory for more appBuilder files
   for i in "$ROOTDIR/AppBuilder/"*.appBuilder; do
-    if [ "x$i" != "x" ]; then
+    if [ -n $i ]; then
       let appCounter++
       title=`head -1 $i`
       title=${title#"#"}
@@ -1273,7 +1278,7 @@ while [ $bailFlag == "true" ] ; do
 bailFlag=false
 # NOTE: machine detection is now done at the top of this script
 # and does not use detect_machine.sh
-if [ "${MACHINE_ID}x" == "x" ] ; then
+if [ -z $MACHINE_ID ]; then
   "$tool" --clear --backtitle "NEMS Application Builder" \
   --title "Unknown machine" --yesno \
   "Need to add NEMS configuration for this machine before trying again!\
@@ -1297,8 +1302,8 @@ fi
 cd $NEMSDIR/src
 autonote "CONFOPT=$CONFOPT MAKEOPT=$MAKEOPT"
 AUTOCONFOPT=$( autoconfopt )
-if [[ "${AUTOCONFOPT}Q" == Q ]] ; then
-    if [[ "${CONFOPT}Q" == Q ]] ; then
+if [[ -z $AUTOCONFOPT ]] ; then
+    if [[ -z $CONFOPT ]] ; then
         conf_mode="coupled"
         CONFOPT="coupled_$COMPILER$MACHINE_ID"
     else
@@ -1325,7 +1330,7 @@ Please use the CHOSEN_MODULE variable instead." \
   14 25  "Invalid appBuilder file"
   exit 10
 fi
-if [[ "Q$CHOSEN_MODULE" == "Q" ]] ; then
+if [[ -z $CHOSEN_MODULE ]] ; then
     fail "The appBuilder file did not set the CHOSEN_MODULE variable. Please add a module in the modulefiles directory and set the CHOSEN_MODULE variable in your appBuilder file to a path relative to the app-level modulefiles directory.  This is usually as simple as copying the environment_<platform>() function contents into modulefiles, one file per platform." \
 19 60
     exit 11
@@ -1540,7 +1545,7 @@ elif ( [[ $legacyNmmFlag == "true" ]] ); then
 fi
 
 # turn COMP into a single string with commas
-if [[ "x$COMP" != "x" ]] ; then
+if [[ -n $COMP ]] ; then
   COMPOPT="COMP=,${COMP#","},"
 else
   COMPOPT=""

--- a/NEMS/NEMSAppBuilder
+++ b/NEMS/NEMSAppBuilder
@@ -1092,7 +1092,6 @@ if [[ $appCounter != 1 && "$tool" != autobuild ]]; then
   bailFlag=true
   while [ $bailFlag == "true" ] ; do
   bailFlag=false
-  echo $tool
   "$tool" --clear --backtitle "NEMS Application Builder" \
     --title "Welcome" --msgbox "Welcome to the NOAA Environmental Modeling System (NEMS) \
 Application Builder. \

--- a/NEMS/src/configure
+++ b/NEMS/src/configure
@@ -7,7 +7,7 @@ if [[ ! -d "conf" ]] ; then
     exit 1
 fi
 
-if [[ -z "$CHOSEN_MODULE" ]] ; then 
+if [[ -z "$CHOSEN_MODULE" ]] ; then
     echo "WARNING: modulefile was not supplied as the second argument" 1>&2
     echo "If possible, specify a modulefile relative to ../../modulefiles" 1>&2
     echo "I will guess the correct modulefile for you." 1>&2
@@ -94,6 +94,16 @@ elif [[ $1 = gsm_intel_wcoss_c ]]; then
      copy_diff_files ESMFVersionDefine_ESMF_NUOPC.h              ESMFVersionDefine.h
      set +x
      echo "NEMS/GSM build on Wcoss using Intel and ESMF v7.0.0"
+
+elif [[ $1 = gsm_intel_pleiades ]]; then
+     set -x
+     copy_diff_files ../../conf/configure.nems.Pleiades.intel_gsm conf/configure.nems
+     touch conf/externals.nems
+     CHOSEN_MODULE="${CHOSEN_MODULE:-pleiades/ESMF_700_gsm}"
+     copy_diff_mod "../../modulefiles/$CHOSEN_MODULE"      conf/modules.nems
+     copy_diff_files ESMFVersionDefine_ESMF_NUOPC.h              ESMFVersionDefine.h
+     set +x
+     echo "NEMS/GSM build on Pleiades using Intel and ESMF v7.0.0"
 #
 # Coupled
 #
@@ -130,6 +140,13 @@ elif [[ $1 = coupled_linux_gnu ]]; then
      copy_diff_files ../../conf/externals.nems.Linux.gnu conf/externals.nems
      copy_diff_files ESMFVersionDefine_ESMF_NUOPC.h ESMFVersionDefine.h
      echo "Coupled NEMS build on Linux using GNU and ESMF v7.0.0"
+elif [[ $1 = coupled_intel_pleiades ]]; then
+     copy_diff_files ../../conf/configure.nems.Pleiades.intel conf/configure.nems
+     copy_diff_files ../../conf/externals.nems.Pleiades conf/externals.nems
+     CHOSEN_MODULE="${CHOSEN_MODULE:-pleiades/ESMF_NUOPC}"
+     copy_diff_mod "../../modulefiles/$CHOSEN_MODULE" conf/modules.nems
+     copy_diff_files ESMFVersionDefine_ESMF_NUOPC.h ESMFVersionDefine.h
+     echo "Coupled NEMS build on Pleiades using Intel and ESMF v7.0.0"
 
 #
 # help message

--- a/conf/configure.nems.Pleiades.intel
+++ b/conf/configure.nems.Pleiades.intel
@@ -71,8 +71,8 @@ EXTLIBS_POST = $(NEMSIO_LIB)  \
                $(NETCDF_LIB)  \
                $(SYS_LIB)
 ###
-FC          = ifort -lmpi -xSSE4.2 -g -traceback -openmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
-F77         = ifort -lmpi -xSSE4.2 -g -traceback -openmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
+FC          = ifort -lmpi -xSSE4.2 -g -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -convert big_endian -assume byterecl -mkl=sequential
+F77         = ifort -lmpi -xSSE4.2 -g -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -convert big_endian -assume byterecl -mkl=sequential
 FREE         = -free
 FIXED        = -fixed
 R8           = -r8

--- a/conf/configure.nems.Pleiades.intel
+++ b/conf/configure.nems.Pleiades.intel
@@ -1,0 +1,107 @@
+## NEMS configuration file
+##
+## Platform: Pleiades
+## Compiler: Intel with IntelMPI
+
+SHELL           = /bin/sh
+
+###################### PHYS_MODE ##### CHEM_MODE ###############################
+#
+#    
+#
+
+PHYS_MODE	= compile
+CHEM_MODE	= compile
+
+################################################################################
+## Include the common configuration parts
+
+include         $(TOP)/conf/configure.nems.NUOPC
+
+################################################################################
+## Other settings
+
+NETCDF_INC   = -I${NETCDF}/include
+NETCDF_LIB   = -L${NETCDF}/lib -lnetcdf -lnetcdff
+
+LIBDIR=/nobackupp8/dtkleist/save/ncep/nwprod/lib
+LIBDIR=/nobackupp8/akubaryk/save/nwprod/lib
+PARADIR=/nobackupp8/dtkleist/save/supplibs/lib
+POSTDIR=/nobackupp8/akubaryk/save/gfs/Q1FY15/projects/post/sorc/ncep_post.fd
+CRTMDIR=/nobackupp8/akubaryk/save/crtm/2.2.3
+
+NEMSIO_INC   = -I${LIBDIR}/incmod/nemsio
+NEMSIO_LIB   = -L${LIBDIR} -lnemsio
+
+BACIO_LIB    = -L${LIBDIR} -lbacio_v2.0.1_4
+W3_LIB       = -L${LIBDIR} -lw3nco_d -lw3emc_v2.2.0_d
+SP_LIB       = -L${LIBDIR} -lsp_v2.0.2_d
+SYS_LIB      =
+ 
+EXTLIBS      = $(NEMSIO_LIB) \
+               $(BACIO_LIB)  \
+               $(W3_LIB)     \
+               $(SP_LIB)     \
+               $(NETCDF_LIB) \
+               $(ESMF_LIB)   \
+               $(SYS_LIB) -lm
+
+## for the post quilting option
+POSTMOD     = ${POSTDIR}/incmod/post_4
+POST_INC    = -I${POSTDIR}/incmod/post_4
+POST_LIB    = -L${POSTDIR} -lnceppost
+W3_POST_LIB = -L${LIBDIR}  -lw3nco_4 -lw3emc_4
+CRTM_LIB    = -L${CRTMDIR} -lcrtm_v2.2.3
+G2_LIB      =  -L${LIBDIR} -lg2tmpl -lg2_4  -L${PARADIR} -ljasper -lpng -lz
+XML_LIB     = -L${LIBDIR} -lxmlparse
+SIGIO_LIB   = -L${LIBDIR} -lsigio_4
+SFCIO_LIB   = -L${LIBDIR} -lsfcio
+
+EXTLIBS_POST = $(NEMSIO_LIB)  \
+               $(POST_LIB)    \
+               $(W3_POST_LIB) \
+               $(XML_LIB)     \
+               $(G2_LIB)      \
+               $(BACIO_LIB)   \
+               $(SIGIO_LIB)   \
+               $(SFCIO_LIB)   \
+               $(SP_LIB)      \
+               $(CRTM_LIB)    \
+               $(ESMF_LIB)    \
+               $(NETCDF_LIB)  \
+               $(SYS_LIB)
+###
+FC          = ifort -lmpi -xSSE4.2 -g -traceback -openmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
+F77         = ifort -lmpi -xSSE4.2 -g -traceback -openmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
+FREE         = -free
+FIXED        = -fixed
+R8           = -r8
+
+FINCS        = $(ESMF_INC) $(NEMSIO_INC) $(NETCDF_INC)
+#TRAPS        =
+#TRAPS        = -g -fno-inline -no-ip -traceback -ftrapuv -fpe0 -ftz -check all -check noarg_temp_created -fp-stack-check
+
+FFLAGS       = $(TRAPS) $(FINCS) -fp-model strict
+
+OPTS_NMM     = -g -fno-inline -no-ip -traceback -ftrapuv -fpe0 -ftz -check all -check noarg_temp_created -fp-stack-check
+OPTS_GFS     = -O3
+#OPTS_GFS     = -O0 -g -traceback
+OPTS_GEN     = -O3
+OPTS_FIM     = -O3
+
+FFLAGM_DEBUG =
+
+FFLAGS_NMM   = $(OPTS_NMM) $(FFLAGS)
+FFLAGS_GFS   = $(OPTS_GFS) $(FFLAGS) $(FREE)
+FFLAGS_GFSF  = $(OPTS_GFS) $(FFLAGS) $(FIXED)
+FFLAGS_GEN   = $(OPTS_GEN) $(FFLAGS)
+FFLAGS_FIM   = $(OPTS_FIM) $(FFLAGS)
+
+FPP          = -fpp
+CPP          = /lib/cpp -P -traditional
+CPPFLAGS     = -DENABLE_SMP -DCHNK_RRTM=8 -DNEMS_GSM
+
+AR           = ar
+ARFLAGS      = -r
+
+RM           = rm

--- a/conf/configure.nems.Pleiades.intel_gsm
+++ b/conf/configure.nems.Pleiades.intel_gsm
@@ -1,0 +1,113 @@
+## NEMS configuration file
+##
+## Platform: Pleiades
+## Compiler: Intel with IntelMPI
+
+SHELL           = /bin/sh
+
+################################################################################
+## Include the common configuration parts
+
+include         $(TOP)/conf/configure.nems.NUOPC
+
+###################### PHYS_MODE ##### CHEM_MODE ###############################
+#
+#    
+#
+
+PHYS_MODE	= compile
+CHEM_MODE	= compile
+ifeq ($(PHYS_MODE),compile)
+       PHYS_LIB = $(TOP)/atmos/gsm/gsmphys
+       PHYS_INC = $(TOP)/atmos/gsm/gsmphys
+       PHYS_DIR = $(TOP)/atmos/gsm/gsmphys
+endif
+ifeq ($(CHEM_MODE),compile)
+        CHEM_LIB = $(TOP)/chem
+        CHEM_INC = $(TOP)/chem/gocart/src/Config/
+        CHEM_DIR = $(TOP)/chem
+       CHEM_MOD = $(TOP)/chem/gocart/${ARCH}/include
+      ESMADIR = chem/gocart
+endif
+
+
+################################################################################
+## Other settings
+
+LIBDIR=/nobackupp8/dtkleist/save/ncep/nwprod/lib
+PARADIR=/nobackupp8/dtkleist/save/supplibs/lib
+POSTDIR=/nobackupp8/akubaryk/save/gfs/Q1FY15/projects/post/sorc/ncep_post.fd
+CRTMDIR=/nobackupp8/dtkleist/save/crtm/CRTM_REL-2.2.1/crtm_v2.2.1/lib
+
+NETCDF_INC   = -I${NETCDF}/include
+NETCDF_LIB   = -L${NETCDF}/lib -lnetcdf -lnetcdff
+
+NEMSIO_INC   = -I${LIBDIR}/incmod/nemsio_v2.2.1
+NEMSIO_LIB   = -L${LIBDIR} -lnemsio_v2.2.1
+
+BACIO_LIB    = -L${LIBDIR} -lbacio_v2.0.1_4
+W3_LIB       = -L${LIBDIR} -lw3nco_v2.0.6_d -lw3emc_v2.2.0_d
+SP_LIB       = -L${LIBDIR} -lsp_v2.0.2_d
+SYS_LIB      =
+ 
+EXTLIBS      = $(NEMSIO_LIB) $(BACIO_LIB) $(W3_LIB) $(SP_LIB) $(NETCDF_LIB) $(ESMF_LIB) $(SYS_LIB) -lm
+
+## for the post quilting option
+POSTMOD     = ${POSTDIR}/incmod/post_4
+POST_INC    = -I${POSTDIR}/incmod/post_4
+POST_LIB    = -L${POSTDIR} -lnceppost
+W3_POST_LIB = -L${LIBDIR}  -lw3nco_4 -lw3emc_4
+CRTM_LIB    = -L${CRTMDIR} -lcrtm
+G2_LIB      =  -L${LIBDIR} -lg2tmpl -lg2_4  -L${PARADIR} -ljasper -lpng -lz
+XML_LIB     = -L${LIBDIR} -lxmlparse
+SIGIO_LIB   = -L${LIBDIR} -lsigio_4
+SFCIO_LIB   = -L${LIBDIR} -lsfcio
+
+EXTLIBS_POST = $(NEMSIO_LIB)  \
+               $(POST_LIB)    \
+               $(W3_POST_LIB) \
+               $(XML_LIB)     \
+               $(G2_LIB)      \
+               $(BACIO_LIB)   \
+               $(SIGIO_LIB)   \
+               $(SFCIO_LIB)   \
+               $(SP_LIB)      \
+               $(CRTM_LIB)    \
+               $(ESMF_LIB)    \
+               $(NETCDF_LIB)  \
+               $(SYS_LIB)
+###
+FC          = ifort -lmpi -xSSE4.2 -g -traceback -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
+F77         = ifort -lmpi -xSSE4.2 -g -traceback -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
+FREE         = -free
+FIXED        = -fixed
+R8           = -r8
+
+FINCS        = $(ESMF_INC) $(NEMSIO_INC) $(NETCDF_INC)
+#TRAPS        =
+#TRAPS        = -g -fno-inline -no-ip -traceback -ftrapuv -fpe0 -ftz -check all -check noarg_temp_created -fp-stack-check
+
+FFLAGS       = $(TRAPS) $(FINCS) -fp-model strict
+
+OPTS_NMM     = -g -fno-inline -no-ip -traceback -ftrapuv -fpe0 -ftz -check all -check noarg_temp_created -fp-stack-check
+OPTS_GFS     = -O3
+#OPTS_GFS     = -O0 -g -traceback
+OPTS_GEN     = -O3
+OPTS_FIM     = -O3
+
+FFLAGM_DEBUG =
+
+FFLAGS_NMM   = $(OPTS_NMM) $(FFLAGS)
+FFLAGS_GFS   = $(OPTS_GFS) $(FFLAGS) $(FREE)
+FFLAGS_GFSF  = $(OPTS_GFS) $(FFLAGS) $(FIXED)
+FFLAGS_GEN   = $(OPTS_GEN) $(FFLAGS)
+FFLAGS_FIM   = $(OPTS_FIM) $(FFLAGS)
+
+FPP          = -fpp
+CPP          = /lib/cpp -P -traditional
+CPPFLAGS     = -DENABLE_SMP -DCHNK_RRTM=8 -DNEMS_GSM
+
+AR           = ar
+ARFLAGS      = -r
+
+RM           = rm

--- a/conf/configure.nems.Pleiades.intel_gsm
+++ b/conf/configure.nems.Pleiades.intel_gsm
@@ -77,14 +77,13 @@ EXTLIBS_POST = $(NEMSIO_LIB)  \
                $(NETCDF_LIB)  \
                $(SYS_LIB)
 ###
-FC          = ifort -lmpi -xSSE4.2 -g -traceback -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
-F77         = ifort -lmpi -xSSE4.2 -g -traceback -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -openmp -convert big_endian -assume byterecl -mkl=sequential
+FC          = ifort -lmpi -xSSE4.2 -g -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -convert big_endian -assume byterecl -mkl=sequential
+F77         = ifort -lmpi -xSSE4.2 -g -qopenmp -mkl=sequential -align array32byte -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -convert big_endian -assume byterecl -mkl=sequential
 FREE         = -free
 FIXED        = -fixed
 R8           = -r8
 
 FINCS        = $(ESMF_INC) $(NEMSIO_INC) $(NETCDF_INC)
-#TRAPS        =
 #TRAPS        = -g -fno-inline -no-ip -traceback -ftrapuv -fpe0 -ftz -check all -check noarg_temp_created -fp-stack-check
 
 FFLAGS       = $(TRAPS) $(FINCS) -fp-model strict

--- a/modulefiles/pleiades/wam-ipe
+++ b/modulefiles/pleiades/wam-ipe
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# This script is responsible for loading modules that are compatible with
+# the NUOPC Layer version used in NEMS.
+
+module use -a /u/akubaryk/modulefiles
+module load comp-intel mpi-sgi/mpt.2.14r19 hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/modulefiles/pleiades/wam-ipe
+++ b/modulefiles/pleiades/wam-ipe
@@ -4,4 +4,4 @@
 # the NUOPC Layer version used in NEMS.
 
 module use -a /u/akubaryk/modulefiles
-module load comp-intel mpi-sgi/mpt.2.14r19 hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial
+module load comp-intel mpi-sgi/mpt.2.14r19 hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial esmf/7.1.0bs34

--- a/scripts/compsets/config/compute.config
+++ b/scripts/compsets/config/compute.config
@@ -11,6 +11,9 @@ if [ $WAM_IPE_COUPLING = .true. ] ; then
 fi
 export PE1=${PE1:-$TASKS}
 
+export TASKPN=$((TPN/NTHREADS))
+export NODES=`python -c "from math import ceil; print str(int(ceil(float($TASKS)/$TASKPN)))"`
+
 if [ $NTHREADS -gt 1 ] ; then
 	export FCST_LAUNCHER=${FCST_LAUNCHER:-"$APRUN -np $TASKS -nt $NTHREADS"}
 else

--- a/scripts/compsets/config/pleiades.config
+++ b/scripts/compsets/config/pleiades.config
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+### THEIA SETUP ###
+
+## some lsf/user defaults, should be loaded already but need some defaults just in case
+export ACCOUNT=${ACCOUNT:-s1452}
+export QUEUE=${QUEUE:-devel}
+
+## initialize modules
+. /apps/lmod/lmod/init/bash
+
+## computational stuff
+export TPN=${TPN:-24}
+export MPICH_FAST_MEMCPY=${MPICH_FAST_MEMCPY:-'ENABLE'}
+export MPI_BUFS_PER_PROC=${MPI_BUFS_PER_PROC:-2048}
+export MPI_BUFS_PER_HOST=${MPI_BUFS_PER_HOST:-2048}
+export MKL_NUM_THREADS=${MKL_NUM_THREADS:-1}
+
+## system directories
+export STMP=${STMP:-/nobackupp8/$LOGNAME/scrub/stmp}
+export PTMP=${PTMP:-/nobackupp8/$LOGNAME/scrub/ptmp}
+
+## executables/scripts
+export SIGHDR=${SIGHDR:-/nobackupp8/dtkleist/save/ncep/nwprod/exec/global_sighdr}
+export SFCHDR=${SFCHDR:-/nobackupp8/dtkleist/save/ncep/nwprod/exec/global_sfchdr}
+export NEMSIOGET=${NEMSIOGET:-/nobackupp8/akubaryk/save/nems/util/nemsio_get}
+export APRUN=${APRUN:-`which mpiexec_mpt`}
+export NDATE=${NDATE:-/nobackupp8/akubaryk/save/gfs/Q1FY15/projects/verif/nwprod/util/exec/ndate}
+export MDATE=${MDATE:-/nobackupp8/akubaryk/save/gfs/Q1FY15/projects/verif/nwprod/util/exec/mdate}
+
+## model-specific input directories
+export DATADIR=${DATADIR:-/nobackup/akubaryk/save/IPE_DATA/data} # contains fix files and grids
+export WAMINDIR=${WAMINDIR:-/nobackup/akubaryk/data/wam} # time-varying F10.7 and Kp
+
+## PBS stuff
+export SCHEDULER_SUB=${SCHEDULER_SUB:-'qsub'}
+export SCHEDULER=${SCHEDULER:-'#PBS'}
+export SUBFLAG1=${SUBFLAG1:-'$SCHEDULER -N ${JOBNAME}'}
+export SUBFLAG2=${SUBFLAG2:-'$SCHEDULER -A ${ACCOUNT}'}
+export SUBFLAG3=${SUBFLAG3:-'$SCHEDULER -l walltime=${WALLCLOCK}'}
+export SUBFLAG4=${SUBFLAG4:-'$SCHEDULER -o ${ROTDIR}/fcst.%J'}
+export SUBFLAG5=${SUBFLAG5:-'$SCHEDULER -e ${ROTDIR}/fcst.%J'}
+export SUBFLAG6=${SUBFLAG6:-'$SCHEDULER -l select=${NODES}:ncpus=${TASKPN}:model=san'}
+export SUBFLAG7=${SUBFLAG7:-'$SCHEDULER -q ${QUEUE}'}
+export SUBFLAG8=${SUBFLAG8:-'$SCHEDULER -W umask=027'}


### PR DESCRIPTION
Just want a sanity check on this. (As far as I can tell) the only things that could impact other systems are the changes to the string checking in NEMS/NEMSAppBuilder, but they follow standard convention. The `[ "x${var}" != "x" ]` was throwing fits on Pleiades, which has a newer version of bash, 4.3.42 (compared to 4.2.46 Theia and 4.1.2 WCOSS).