### PR TITLE
Add fix for vector regridding to work after ESMF 7.0.0

### DIFF
--- a/scripts/compsets/exglobal/exglobal_fcst_nems.sh
+++ b/scripts/compsets/exglobal/exglobal_fcst_nems.sh
@@ -951,6 +951,7 @@ if [[ $ENS_NUM -le 1 ]] ; then
       ln -fs $GRDI  grid_ini
       ln -fs $GRDI2 grid_ini2
       ln -fs $SIGI2 sig_ini2
+      ln -fs $FORT1051 fort.1051
     else
       export RESTART=.false.
     fi
@@ -1307,9 +1308,6 @@ if [ $IDEA = .true. ]; then
    KP3HR=`grep ${INI_YEAR}-${INI_MONTH}-${INI_DAY}T${INI_HOUR} wam_input_f107_kp.txt | awk '{print $3}'`
 
    #convert from kp to ap
-   AP3HR=`expr ${KP3HR} \* 4`
-
-   #now a better one
    KPX=(0 1 2  3  4  5  6   7   8   9)
    APX=(0 4 7 15 27 48 80 132 207 400)
 
@@ -1411,7 +1409,7 @@ cat  > IPE.inp <<EOF
   kp_eld=${KP3HR}
 /
 &nmswitch
-  duration=43200
+  duration=$(((FHMAX-FHINI)*3600))
   fac_bm=1.00
   iout(1)=1
   iout(2)=60


### PR DESCRIPTION
This pull request is to merge  bob_vector_fix into development. It allows the vector regridding code to work in versions of ESMF after 7.0.0. There will still be problems if the code is used with an early snapshot of ESMF 7.1.0, but anything after ESMF_710_beta_snapshot_19 should be fine. 
I added a check that should return an error if code before that snapshot is used. 

I ran tests on Theia using swpc%20130316_1hr_spacewx_gsm%wam%T62_ipe%80x170 on ESMF 7.0.0, ESMF 7.1.0 beta snapshot 31, and a test that simulated what would happen if a version of ESMF before 19 (or some other problem that produced bad coordinates) happened to exercise the check. All worked as expected. 
