### PR TITLE
Merge restart_bug_fix into development

### DIFF
--- a/IPELIB/src/neutral/module_neutral.f90
+++ b/IPELIB/src/neutral/module_neutral.f90
@@ -107,22 +107,6 @@
      END IF
 
 
-! array initialization - don't do this......
-!SMS$IGNORE BEGIN
-!      ON_m3  = zero
-!      HN_m3  = zero
-!      N2N_m3 = zero
-!      O2N_m3 = zero
-!      HE_m3  = zero
-!      N4S_m3 = zero
-!      TN_k   = zero
-!      TINF_k = zero
-!      Un_ms1 = zero
-!      on_m3_msis = zero
-!      o2n_m3_msis = zero
-!      n2n_m3_msis = zero
-!      tn_k_msis = zero
-!SMS$IGNORE END
 
 !SMS$PARALLEL(dh, lp, mp) BEGIN
       apex_longitude_loop: DO mp = 1,mpstop
@@ -219,9 +203,14 @@
 ! copy across the msis parameters:
 !
                 if ( sw_use_wam_fields_for_restart ) then
-                   print*, '**** GEORGE **** First Call of IPE, Using Read-in WAM fields', mp,lp
+
+                   do jth=1,3
+                     do i=IN,IS
+                       vn_ms1(jth,i-IN+1) = vn_ms1_4output(i-IN+1,lp,mp,jth)
+                     end do
+                   end do
+
                 else
-                   print *, '**** GEORGE **** First Call of IPE, Using MSIS ', mp,lp
 
                    on_m3( IN:IS,lp,mp) =  on_m3_msis(IN:IS)
                    o2n_m3(IN:IS,lp,mp) = o2n_m3_msis(IN:IS)


### PR DESCRIPTION
This pull request is to merge  restart_bug_fix into development .
The changes brought in by this feature include :
* Copying of vn_ms1_4output to vn_ms1 within module_neutral on the first time step within IPE


Before issuing this pull request, I have not brought in the latest changes from development.
This branch has been tested on :
* Theia with Intel/16.9 compilers on the March 2013, 5 day with restarts test.

Additionally, a one day test with restart was compared against a two-day run. Relative to the development branch, the neutral and plasma fields are in better agreement after the restart (beyond 1 day of simulation time), though the restart issue ( Issue #33 ) does not look completely resolved.


For this pull request, I am requesting review from @twfang . At your convenience, download this branch using

git fetch
git checkout origin/restart_bug_fix -b restart_bug_fix

and run a 5 day test confirming the successful completion of the code.
