### PR TITLE
New Version Release

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -12,3 +12,7 @@ When using the same machine and model configuration, indicate what should happen
 If possible, indicate the last known working version on that branch.
 
 Feel free to include additional comments, figures, plots that help describe your issue.
+
+@mentions should be used to draw attention to developers you think can help resolve the issue most effectively.
+
+## Be sure to delete this line and indicate the severity of the problem using the labels

--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,0 +1,14 @@
+### Observed Behavior
+Provide details on what machine you are running on, what configuration (initial conditions and compset scripts)
+
+Indicate the hash ID and branch where you first noticed the problem. 
+
+Describe the incorrect behavior of the WAM-IPE, 
+identifying particular source code (if possible) that may be the culprit
+
+### Expected Behavior
+When using the same machine and model configuration, indicate what should happen in the source code
+
+If possible, indicate the last known working version on that branch.
+
+Feel free to include additional comments, figures, plots that help describe your issue.

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,16 @@
+This pull request is to merge  < name of feature branch > into < name of destination branch > .
+The changes brought in by this feature include :
+* Modifications to existing source code
+* Modifications to existing compset scripts
+* New variables or variable name changes
+* New source code or scripts
+
+This branch has been tested on :
+* < compute cluster > with < compilers > on the < test case name >.
+* " "
+* " "
+
+Model output and difference plots with the current version of the < name of destination branch > can be found at : 
+< link to documentation of testing >
+
+For this pull request, I am requesting review from @mentions.

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -5,6 +5,7 @@ The changes brought in by this feature include :
 * New variables or variable name changes
 * New source code or scripts
 
+Before issuing this pull request, I < have/have not > brought in the latest changes from < destination branch >.
 This branch has been tested on :
 * < compute cluster > with < compilers > on the < test case name >.
 * " "


### PR DESCRIPTION
The Release Candidate branch is to be merged into maser for new release. The details of the new features of this release are given in RC0.0.7-0.0.9, and are summarized here : 
Relative to MS0.6, this release will include 2-D domain decomposition within IPE and an updated IPE cap to handle the new decomposition.

This branch has been run in 5 day + 5 day restart configuration and compared with MS0.6 using the march2013_regression.config configuration file now included with the source code. To run the test case used to check this branch you will need to edit the march2013_regression.config file to specify the appropriate `STMP` and `PTMP` directories.
```
cd scripts/compsets/
```
Edit the configuration file, then submit the job  
```
./submit.sh march2013_regression.config
```
