### PR TITLE
Updated mediator

### DIFF
--- a/IPELIB/src/plot/Compare_raw_IPE.sh
+++ b/IPELIB/src/plot/Compare_raw_IPE.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#set -ax
+# ********* Settings that you should modify ********* #
+
+
+# Reference output directory
+REFDIR='/scratch3/NCEPDEV/swpc/scrub/Joseph.Schoonover/ptmp/Joseph.Schoonover/march2013_old_mediator_1x80_5day/'
+
+# Comparison directory
+COMPDIR='/scratch3/NCEPDEV/swpc/scrub/Raffaele.Montuoro/ptmp/Raffaele.Montuoro/march2013_updated_mediator_1x80_5d/'
+
+
+
+# ----------------------------------------------------------------------- #
+ 
+
+# Create a list of neutral files that are not bitwise identical
+
+for file in ${REFDIR}ipe_grid_neutral_params.*
+do
+  filename=$(echo $file | awk -F / '{print $NF}')
+  if [ -e $COMPDIR/$filename ]
+  then
+
+     if ! cmp ${REFDIR}${filename} ${COMPDIR}${filename} >/dev/null 2>&1
+     then
+
+       echo $filename
+       echo $filename >> difference_list.txt
+
+       echo $filename >> comparisons.txt
+       echo '-----------------------' >> comparisons.txt
+       ./comp ${REFDIR}${filename} ${COMPDIR}${filename}  > raw.txt
+       grep "DIFF REP" raw.txt >> comparisons.txt
+       echo '-----------------------' >> comparisons.txt
+ 
+     fi
+ 
+
+
+  fi
+
+done
+
+
+#diff -q ${REFDIR}'ipe_grid_neutral_params.*' ${COMPDIR}'ipe_grid_neutral_params.*'
+
+
+#more neutral_files.txt
+

--- a/IPELIB/src/plot/IPE_Comparisons.f90
+++ b/IPELIB/src/plot/IPE_Comparisons.f90
@@ -1,0 +1,343 @@
+! IPEtoHeightGrid.f90
+!
+!  Authors : George Millward  (george.millward@noaa.gov)
+!            Joe Schoonover   (joseph.schoonover@noaa.gov)
+!
+!  Cooperative Institute for Research in Environmental Sciences (CIRES)
+!  National Oceanographic and Atmospheric Administration (NOAA)
+!  Space Weather Prediction Center (SWPC)
+!
+!
+
+
+PROGRAM IPEtoHeightGrid
+
+USE module_precision
+USE module_IPE_dimension,ONLY: NMP, NLP, NPTS2D, ISTOT
+USE module_input_parameters
+USE module_FIELD_LINE_GRID_MKS,ONLY: MaxFluxTube, JMIN_IN, JMAX_IS, JMIN_ING, JMAX_ISG
+USE module_init_plasma_grid
+
+
+  IMPLICIT NONE
+
+
+
+
+  REAL(kind=real_prec8)                                 :: dtotinv, factor, d, fac
+  REAL(kind=real_prec8),DIMENSION(:,:,:,:), ALLOCATABLE :: facfac_interface,dd_interface
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: oplus_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: hplus_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: heplus_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: nplus_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: noplus_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: o2plus_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: n2plus_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: oplus2d_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: oplus2p_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: tn_ft
+  REAL(kind=real_prec),DIMENSION(:,:,:), ALLOCATABLE    :: vn_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: on_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: n2n_ft
+  REAL(kind=real_prec),DIMENSION(:,:), ALLOCATABLE      :: o2n_ft
+  REAL(kind=real_prec8),DIMENSION(:,:,:), ALLOCATABLE   :: oplus_fixed
+
+  CHARACTER(100) :: filename
+  CHARACTER(500) :: plasmaFile
+  CHARACTER(500) :: neutralFile1
+  CHARACTER(500) :: neutralFile2
+  CHARACTER(500) :: gridFile
+  CHARACTER(500) :: outputDir
+  
+
+  LOGICAL :: plasmaFileGiven, neutralFileGiven, outputDirGiven, gridFileGiven
+
+
+    CALL InitializeFromCommandLine( )
+
+    CALL read_input_parameters ( )
+
+    PRINT*, "AllocateArrays"
+    CALL AllocateArrays( )
+
+    PRINT*, "ReadGridAndPlasmaFiles"
+    CALL ReadGridAndPlasmaFiles( )
+ 
+!   PRINT*, "InterpolateOntoFixedHeightGrid"
+!   CALL InterpolateOntoFixedHeightGrid( )
+
+!   PRINT*,"WriteToNetCDF"
+!   CALL WriteToNetCDF( )
+
+    PRINT*,"CleanupArrays"
+    CALL CleanupArrays( )
+
+
+
+CONTAINS
+ SUBROUTINE InitializeFromCommandLine( )
+   IMPLICIT NONE
+
+   INTEGER        :: nArg, argID
+   CHARACTER(500) :: argname
+   LOGICAL        :: fileExists
+   LOGICAL        :: plasmaGiven, neutralsGiven,  gridGiven, outputGiven
+
+   CHARACTER(500) :: argv(3)
+   
+
+!    plasmaFileGiven   = .FALSE. 
+!    gridFileGiven     = .FALSE.
+!    neutralFileGiven = .FALSE.
+!    outputDirGiven    = .FALSE.
+
+!    plasmaGiven    = .FALSE.
+!    neutralsGiven  = .FALSE.
+!    gridGiven      = .FALSE.
+!    outputGiven    = .FALSE.
+
+!    nArg = command_argument_count( )
+
+     IF( .true. ) THEN
+!    IF( nArg > 0 )THEN
+!
+!       DO argID = 1, nArg
+! 
+!         CALL get_command_argument( argID, argName )
+
+!         SELECT CASE( TRIM(argName) )
+
+!            CASE("--plasma-file")
+!               plasmaGiven = .TRUE.
+!               plasmaFileGiven = .TRUE.
+!            CASE("--neutral-file1")
+!               neutralFileGiven = .TRUE.
+!               neutralFile1  = TRIM(argName) ! Capture the directory name
+!               print *,'argname = ' // trim(argName)
+!            CASE("--neutral-file2")
+!               neutralFileGiven = .TRUE.
+!               neutralFile2  = TRIM(argName) ! Capture the directory name
+!               print *,'argname = ' // trim(argName)
+!            CASE("--grid-file")
+!               gridGiven = .TRUE.
+!            CASE("--output-dir")
+!               outputGiven = .TRUE.
+!               outputDirGiven = .TRUE.
+!            CASE DEFAULT
+
+!              IF( plasmaGiven )THEN
+
+!                 plasmaFileGiven = .TRUE.
+!                 plasmaFile  = TRIM(argName) ! Capture the directory name
+!                 plasmaGiven = .FALSE.
+
+!              ELSEIF( gridGiven )THEN
+
+!                 gridFileGiven = .TRUE.
+!                 gridFile  = TRIM(argName)
+!                 gridGiven = .FALSE.
+
+!              ELSEIF( outputGiven )THEN
+
+!                 outputDirGiven = .TRUE.
+!                 outputDir   = TRIM(argName)
+!                 outputGiven = .FALSE.
+!              ENDIF
+
+!         END SELECT 
+!       ENDDO
+
+!       IF( .NOT. plasmaFileGiven .OR. &
+!       IF( .NOT. gridFileGiven )THEN
+!          PRINT*, '  i2hg : A grid file is required'
+!          PRINT*, '  i2hg : Setup Failed.'
+!          STOP
+!       ENDIF
+
+        call getarg(1, neutralFile1)
+        print *,'neutralFile1 = '//trim(neutralFile1)
+        call getarg(2, neutralFile2)
+        print *,'neutralFile2 = '//trim(neutralFile2)
+
+       
+        INQUIRE( FILE = TRIM(neutralFile1), &
+                 EXIST = fileExists )
+        IF( .NOT.(fileExists) )THEN
+          PRINT*, ' Input file :'//TRIM(neutralFile1)//': not found.'
+          PRINT*, '  i2hg : Setup Failed.'
+        ENDIF
+        INQUIRE( FILE = TRIM(neutralFile2), &
+                 EXIST = fileExists )
+        IF( .NOT.(fileExists) )THEN
+          PRINT*, ' Input file :'//TRIM(neutralFile2)//': not found.'
+          PRINT*, '  i2hg : Setup Failed.'
+        ENDIF
+        
+        INQUIRE( FILE = TRIM(gridFile), &
+                 EXIST = fileExists )
+        IF( .NOT.(fileExists) )THEN
+          PRINT*, ' Grid file :'//TRIM(gridFile)//': not found.'
+          PRINT*, '  i2hg : Setup Failed.'
+        ENDIF
+
+        IF( .NOT. outputDirGiven )THEN
+           outputDir = './'
+        ENDIF
+        
+     ELSE
+
+        ! List possible options
+        PRINT*, '  i2hg : IPE to Height Grid'
+        PRINT*, '    A tool for interpolating IPE plasma output onto a fixed height grid.'
+        PRINT*, '--------------------------------------------------------------'
+        PRINT*, '  Usage : i2hg <inputs>                                      '
+        PRINT*, ''
+        PRINT*, ' Required inputs'
+        PRINT*, ''
+        PRINT*, ' --plasma-file /full/path/to/plasma/file '
+        PRINT*, ''
+        PRINT*, ' --grid-file /full/path/to/grid/file'
+        PRINT*, ''
+        PRINT*, ' Optional inputs'
+        PRINT*, ''
+        PRINT*, ' --neutral-file /full/path/to/neutrals/file '
+        PRINT*, ''
+        PRINT*, ' If the neutrals file is not provided, these parameters will  '
+        PRINT*, ' not be included in the netcdf output.'
+        PRINT*, ''
+        PRINT*, ' --output-directory /full/path/to/output directory '
+        PRINT*, ''
+        PRINT*, ' If the output directory is not specified, your current       '
+        PRINT*, ' directory will be used.  '
+        PRINT*, ' '
+        PRINT*, '--------------------------------------------------------------'
+        PRINT*, ' This executable takes READs in the plasma file that was      '
+        PRINT*, ' output by IPE, and interpolates the ions to a fixed height   '
+        PRINT*, ' grid. NmF2, HmF2, and total electron content are also        '
+        PRINT*, ' calculated and all outputs are written to a NetCDF file.     '
+        PRINT*, '--------------------------------------------------------------'
+        STOP
+        
+     ENDIF   
+
+
+ END SUBROUTINE InitializeFromCommandLine
+!
+ SUBROUTINE AllocateArrays( )
+   IMPLICIT NONE
+
+      ALLOCATE ( oplus_ft(NPTS2D,80), &
+                 hplus_ft(NPTS2D,80), &  
+                 heplus_ft(NPTS2D,80), &  
+                 nplus_ft(NPTS2D,80), &  
+                 noplus_ft(NPTS2D,80), &  
+                 o2plus_ft(NPTS2D,80), &  
+                 n2plus_ft(NPTS2D,80), &  
+                 oplus2d_ft(NPTS2D,80), &  
+                 oplus2p_ft(NPTS2D,80), &  
+                 tn_ft(NPTS2D,80), &  
+                 vn_ft(NPTS2D,80,1:3), &  
+                 on_ft(NPTS2D,80), &  
+                 n2n_ft(NPTS2D,80), &  
+                 o2n_ft(NPTS2D,80) ) 
+            
+
+ END SUBROUTINE AllocateArrays
+!
+ SUBROUTINE CleanupArrays( )
+   IMPLICIT NONE
+
+      DEALLOCATE ( oplus_ft, &
+                   hplus_ft, &  
+                   heplus_ft, &  
+                   nplus_ft, &  
+                   noplus_ft, &  
+                   o2plus_ft, &  
+                   n2plus_ft, &  
+                   oplus2d_ft, &  
+                   oplus2p_ft, &  
+                   tn_ft, &  
+                   vn_ft, &  
+                   on_ft, &  
+                   n2n_ft, &  
+                   o2n_ft ) 
+              
+
+ END SUBROUTINE CleanupArrays
+!
+ SUBROUTINE ReadGridandPlasmaFiles()
+   IMPLICIT NONE
+
+   REAL(real_prec), DIMENSION(:,:,:), ALLOCATABLE :: field1, field2
+   REAL(real_prec), DIMENSION(:,:,:,:), ALLOCATABLE :: v1, v2
+   REAL(real_prec), ALLOCATABLE :: tn_k(:,:,:)
+   REAL(real_prec), ALLOCATABLE :: vn_ms1(:,:,:,:)
+   REAL(real_prec), ALLOCATABLE :: on_ms1(:,:,:)
+   REAL(real_prec), ALLOCATABLE :: n2n_ms1(:,:,:)
+   REAL(real_prec), ALLOCATABLE :: o2n_m3(:,:,:)
+
+   CHARACTER(LEN=*), PARAMETER :: vcomp(3) = (/ 'u', 'v', 'w' /)
+   CHARACTER(LEN=*), PARAMETER :: gases(3) = (/ 'O', 'N2', 'O2' /)
+   INTEGER :: i 
+ 
+    CALL init_plasma_grid( )
+
+    ALLOCATE( field1(MaxFluxTube,NLP,NMP), &
+              field2(MaxFluxTube,NLP,NMP), &
+              v1(MaxFluxTube,NLP,NMP,1:3), &
+              v2(MaxFluxTube,NLP,NMP,1:3) )
+
+     OPEN( UNIT = 20, &
+           FILE = TRIM(neutralFile1), &
+           FORM = 'UNFORMATTED', &
+           STATUS = 'OLD' )
+
+     OPEN( UNIT = 40, &
+           FILE = TRIM(neutralFile2), &
+           FORM = 'UNFORMATTED', &
+           STATUS = 'OLD' )
+
+     REWIND(20)
+     REWIND(40)
+
+    
+     READ(20) field1
+     READ(40) field2
+     CALL ComputeDiff(field1, field2, "temp_neutral")
+
+     READ(20) v1
+     READ(40) v2
+     do i = 1, 3
+       field1 = v1(:,:,:,i)
+       field2 = v2(:,:,:,i)
+       CALL ComputeDiff(field1, field2, "wind_neutral: "//trim(vcomp(i)))
+     end do
+
+     do i = 1, 3
+       READ(20) field1
+       READ(40) field2
+       CALL ComputeDiff(field1, field2, trim(gases(i)) // "_Density")
+     end do
+
+     CLOSE(20)
+     CLOSE(40)
+
+    DEALLOCATE( field1, field2, v1, v2 )
+
+ END SUBROUTINE ReadGridandPlasmaFiles
+
+ SUBROUTINE ComputeDiff(field1, field2, label)
+   REAL(real_prec), DIMENSION(:,:,:), INTENT(IN) :: field1, field2
+   CHARACTER(LEN=*), INTENT(IN) :: label
+
+   
+   REAL(real_prec) :: dmin, dmax
+
+   dmin = MINVAL(ABS(field1-field2))
+   dmax = MAXVAL(ABS(field1-field2))
+
+   WRITE(*,*) 'DIFF REP : '//TRIM(label), dmin, dmax, MAXVAL(field1), MAXVAL(field2)
+
+ END SUBROUTINE ComputeDiff
+
+END PROGRAM IPEtoHeightGrid

--- a/IPELIB/src/plot/comp.mak
+++ b/IPELIB/src/plot/comp.mak
@@ -1,0 +1,90 @@
+
+
+FC  = ifort
+OPT = -O3 -fpp
+LIB =
+INC =
+
+OBJS = module_precision.o \
+       module_IPE_dimension.o \
+       FLIP_GRID.o \
+       module_physical_constants.o \
+       module_input_parameters.o \
+       get_pvalue_dipole.o \
+       module_FIELD_LINE_GRID_MKS.o \
+       module_init_plasma_grid.o \
+       module_read_plasma_grid_global.o \
+       module_io.o \
+       module_open_file.o \
+       allocate_arrays.o \
+       get_flip_grid.o \
+       get_sinim.o \
+       module_unit_conversion.o \
+       IPE_Comparisons.o
+
+comp : ${OBJS}	
+	${FC} ${OPT} ${OBJS} ${LIB} ${INC} -o $@
+	mv $@ ../../bin/
+
+
+IPE_Comparisons.o : IPE_Comparisons.f90 module_precision.o module_IPE_dimension.o module_input_parameters.o \
+                    module_FIELD_LINE_GRID_MKS.o module_init_plasma_grid.o
+	${FC} ${OPT} -c IPE_Comparisons.f90 ${INC} -o $@
+
+allocate_arrays.o : ../main/allocate_arrays.f90 \
+                    module_precision.o module_IPE_dimension.o module_FIELD_LINE_GRID_MKS.o \
+                    module_input_parameters.o
+	${FC} ${OPT} -c ../main/allocate_arrays.f90 -o $@
+
+FLIP_GRID.o : ../flip/FLIP_GRID.f
+	${FC} ${OPT} -c ../flip/FLIP_GRID.f -o $@
+
+get_flip_grid.o : ../main/get_flip_grid.f90 FLIP_GRID.o \
+                  module_precision.o module_FIELD_LINE_GRID_MKS.o module_input_parameters.o \
+                  module_physical_constants.o module_unit_conversion.o
+	${FC} ${OPT} -c ../main/get_flip_grid.f90 -o $@
+
+get_sinim.o : ../plasma/get_sinim.f90 \
+              module_precision.o
+	${FC} ${OPT} -c ../plasma/get_sinim.f90 -o $@
+
+module_unit_conversion.o : ../main/module_unit_conversion.f90 module_precision.o
+	${FC} ${OPT} -c ../main/module_unit_conversion.f90 -o $@
+
+get_pvalue_dipole.o : ../plasma/get_pvalue_dipole.f90 module_precision.o
+	${FC} ${OPT} -c ../plasma/get_pvalue_dipole.f90 -o $@
+
+module_init_plasma_grid.o : ../main/module_init_plasma_grid.f90 \
+                            module_read_plasma_grid_global.o module_IPE_dimension.o \
+                            module_precision.o module_physical_constants.o \
+                            module_input_parameters.o module_FIELD_LINE_GRID_MKS.o
+	${FC} ${OPT} -c ../main/module_init_plasma_grid.f90 -o $@
+
+module_read_plasma_grid_global.o : ../main/module_read_plasma_grid_global.f90 \
+                                    module_precision.o module_IPE_dimension.o module_physical_constants.o \
+                                   module_input_parameters.o module_io.o module_FIELD_LINE_GRID_MKS.o \
+                                   module_open_file.o
+	${FC} ${OPT} -c ../main/module_read_plasma_grid_global.f90 -o $@
+
+module_physical_constants.o : ../main/module_physical_constants.f90 \
+                              module_precision.o
+	${FC} ${OPT} -c ../main/module_physical_constants.f90 -o $@
+
+module_io.o : ../main/module_io.f90 module_precision.o module_IPE_dimension.o
+	${FC} ${OPT} -c ../main/module_io.f90 -o $@
+
+module_open_file.o : ../main/module_open_file.f90 module_precision.o module_IPE_dimension.o \
+                     module_input_parameters.o
+	${FC} ${OPT} -c ../main/module_open_file.f90 -o $@
+
+module_input_parameters.o : ../main/module_input_parameters.f90 module_precision.o module_IPE_dimension.o
+	${FC} ${OPT} -c ../main/module_input_parameters.f90 -o $@
+
+module_IPE_dimension.o: ../main/module_IPE_dimension.f90 module_precision.o
+	${FC} ${OPT} -c ../main/module_IPE_dimension.f90 -o $@
+
+module_FIELD_LINE_GRID_MKS.o : ../main/module_field_line_grid.f90 module_precision.o module_IPE_dimension.o
+	${FC} ${OPT} -c ../main/module_field_line_grid.f90 -o $@
+
+module_precision.o : ../main/module_precision.f90
+	${FC} ${OPT} -c ../main/module_precision.f90 -o $@

--- a/NEMS/src/makefile
+++ b/NEMS/src/makefile
@@ -270,6 +270,7 @@ endif
 ################################################################################
 
 CPPFLAGS += $(DEP_FRONTS)
+CPPFLAGS += -DESMF_NETCDF
 
 TARGET = ../exe/NEMS.x
 

--- a/NEMS/src/makefile
+++ b/NEMS/src/makefile
@@ -289,6 +289,8 @@ MAIN = MAIN_NEMS.o
 OBJS = module_MEDIATOR_methods.o \
        module_MEDIATOR.o \
        module_MEDIATOR_SpaceWeather.o \
+       module_MEDIATOR_SWPC_methods.o \
+       module_MEDIATOR_SWPC.o \
        module_EARTH_INTERNAL_STATE.o \
        module_EARTH_GRID_COMP.o \
        module_NEMS_INTERNAL_STATE.o \

--- a/NEMS/src/makefile
+++ b/NEMS/src/makefile
@@ -271,6 +271,7 @@ endif
 
 CPPFLAGS += $(DEP_FRONTS)
 CPPFLAGS += -DESMF_NETCDF
+# CPPFLAGS += -DNEW_WAY_VECTOR    # enables vector rotation in SpaceWeather mediator
 
 TARGET = ../exe/NEMS.x
 

--- a/NEMS/src/module_EARTH_GRID_COMP.F90
+++ b/NEMS/src/module_EARTH_GRID_COMP.F90
@@ -134,6 +134,7 @@
   ! - Mediator
       use module_MEDIATOR,        only: MED_SS     => SetServices
       use module_MEDSpaceWeather, only: MEDSW_SS   => SetServices
+      use module_MED_SWPC,        only: MEDSWPC_SS => SetServices
 
       USE module_EARTH_INTERNAL_STATE,ONLY: EARTH_INTERNAL_STATE        &
                                            ,WRAP_EARTH_INTERNAL_STATE
@@ -3144,7 +3145,7 @@
               file=__FILE__, rcToReturn=rc)
             return  ! bail out
 #endif
-          ! - Two mediator choices currently built into NEMS from internal
+          ! - Three mediator choices currently built into NEMS from internal
           elseif (trim(model) == "nems") then
             call NUOPC_DriverAddComp(driver, trim(prefix), MED_SS, &
               petList=petList, comp=comp, rc=rc)
@@ -3152,6 +3153,11 @@
               line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
           elseif (trim(model) == "spaceweather") then
             call NUOPC_DriverAddComp(driver, trim(prefix), MEDSW_SS, &
+              petList=petList, comp=comp, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+             line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
+          elseif (trim(model) == "swpc") then
+            call NUOPC_DriverAddComp(driver, trim(prefix), MEDSWPC_SS, &
               petList=petList, comp=comp, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
              line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out

--- a/NEMS/src/module_MEDIATOR_SWPC.F90
+++ b/NEMS/src/module_MEDIATOR_SWPC.F90
@@ -303,7 +303,7 @@ module module_MED_SWPC
 
     ! -- if ATM fields are defined on a mesh, the mesh needs to be replaced
     ! -- get min/max height from IPE mesh
-    call NamespaceGet("IPM", importState, mesh=mesh, rc=rc)
+    call NamespaceGet("IPM", exportState, mesh=mesh, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &
       file=__FILE__)) &

--- a/NEMS/src/module_MEDIATOR_SWPC.F90
+++ b/NEMS/src/module_MEDIATOR_SWPC.F90
@@ -1,0 +1,641 @@
+module module_MED_SWPC
+
+  !-----------------------------------------------------------------------------
+  ! Mediator Component.
+  !-----------------------------------------------------------------------------
+
+  use ESMF
+  use NUOPC
+  use NUOPC_Mediator, only: &
+    mediator_routine_SS            => SetServices, &
+    mediator_label_DataInitialize  => label_DataInitialize, &
+    mediator_label_Advance         => label_Advance, &
+    mediator_label_Finalize        => label_Finalize, &
+    mediator_label_CheckImport     => label_CheckImport, &
+    mediator_label_TimestampExport => label_TimestampExport, &
+    mediator_label_SetRunClock     => label_SetRunClock
+
+  use module_MED_SWPC_methods
+  
+  implicit none
+
+  private
+
+  public :: SetServices
+  
+  !-----------------------------------------------------------------------------
+  contains
+  !-----------------------------------------------------------------------------
+  
+  subroutine SetServices(mediator, rc)
+    type(ESMF_GridComp)  :: mediator
+    integer, intent(out) :: rc
+    
+    rc = ESMF_SUCCESS
+    
+    ! the NUOPC mediator component will register the generic methods
+    call NUOPC_CompDerive(mediator, mediator_routine_SS, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    
+    ! --- Initialization phases --------------------------------------
+
+    ! Provide InitializeP0 to switch from default IPDv00 to IPDv03
+    call ESMF_GridCompSetEntryPoint(mediator, ESMF_METHOD_INITIALIZE, &
+      userRoutine=InitializeP0, phase=0, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! IPDv03p1: advertise Fields
+    call NUOPC_CompSetEntryPoint(mediator, ESMF_METHOD_INITIALIZE, &
+      phaseLabelList=(/"IPDv03p1"/), userRoutine=InitializeP1, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! IPDv03p3: realize connected Fields with transfer action "provide"
+    call NUOPC_CompSetEntryPoint(mediator, ESMF_METHOD_INITIALIZE, &
+      phaseLabelList=(/"IPDv03p3"/), userRoutine=InitializeP3, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! IPDv03p4: optionally modify the decomp/distr of transferred Grid/Mesh
+    call NUOPC_CompSetEntryPoint(mediator, ESMF_METHOD_INITIALIZE, &
+      phaseLabelList=(/"IPDv03p4"/), userRoutine=InitializeP4, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! IPDv03p5: realize all Fields with transfer action "accept"
+    call NUOPC_CompSetEntryPoint(mediator, ESMF_METHOD_INITIALIZE, &
+      phaseLabelList=(/"IPDv03p5"/), userRoutine=InitializeP5, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! attach specializing method(s)
+    call NUOPC_CompSpecialize(mediator, specLabel=mediator_label_Advance, &
+      specRoutine=MediatorAdvance, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call NUOPC_CompSpecialize(mediator, specLabel=mediator_label_DataInitialize, &
+      specRoutine=DataInitialize, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call NUOPC_CompSpecialize(mediator, specLabel=mediator_label_Finalize, &
+      specRoutine=Finalize, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    
+  end subroutine SetServices
+  
+  !-----------------------------------------------------------------------------
+
+  subroutine InitializeP0(mediator, importState, exportState, clock, rc)
+    type(ESMF_GridComp)   :: mediator
+    type(ESMF_State)      :: importState, exportState
+    type(ESMF_Clock)      :: clock
+    integer, intent(out)  :: rc
+    
+    rc = ESMF_SUCCESS
+
+    ! Switch to IPDv03 by filtering all other phaseMap entries
+    call NUOPC_CompFilterPhaseMap(mediator, ESMF_METHOD_INITIALIZE, &
+      acceptStringList=(/"IPDv03p"/), rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    
+  end subroutine InitializeP0
+  
+  !-----------------------------------------------------------------------------
+
+  subroutine InitializeP1(mediator, importState, exportState, clock, rc)
+    
+    type(ESMF_GridComp)  :: mediator
+    type(ESMF_State)     :: importState, exportState
+    type(ESMF_Clock)     :: clock
+    integer, intent(out) :: rc
+    
+    rc = ESMF_SUCCESS
+
+    call NamespaceAdd("ATM",importState, &
+      (/ &
+        "height                         ", &
+        "eastward_wind_neutral          ", &
+        "northward_wind_neutral         ", &
+        "upward_wind_neutral            ", &
+        "temp_neutral                   ", &
+        "O_Density                      ", &
+        "O2_Density                     ", &
+        "N2_Density                     "  &
+      /), &
+      "cannot provide", &
+      ungriddedVerticalDim=.true., &
+      fieldOptions=(/ &
+        "none", &
+        "none", &
+        "none", &
+        "none", &
+        "none", &
+        "16.0", &
+        "32.0", &
+        "28.0"  &
+      /), &
+      rc=rc) 
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+#if 0
+    call NamespaceAdd("IPM",importState, &
+      (/ &
+        "eastward_wind_neutral      ", &
+        "eastward_momentum_tendency ", &
+        "northward_momentum_tendency", &
+        "neutral_heating_rate       ", &
+        "o2_dissociation_rate       "  &
+      /), &
+      "cannot provide", &
+      rc=rc) 
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call NamespaceAdd("ATM",exportState, &
+      (/ &
+        "eastward_wind_neutral      ", &
+        "eastward_momentum_tendency ", &
+        "northward_momentum_tendency", &
+        "neutral_heating_rate       ", &
+        "o2_dissociation_rate       "  &
+      /), &
+      "cannot provide", &
+      ungriddedVerticalDim=.true., &
+      rc=rc) 
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+#endif
+
+    call NamespaceAdd("IPM",exportState, &
+      (/ &
+        "eastward_wind_neutral          ", &
+        "northward_wind_neutral         ", &
+        "upward_wind_neutral            ", &
+        "temp_neutral                   ", &
+        "O_Density                      ", &
+        "O2_Density                     ", &
+        "N2_Density                     "  &
+      /), &
+      "cannot provide",rc=rc) 
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call NamespaceAdvertise(rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call NamespacePrint(rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+  end subroutine InitializeP1
+
+  !-----------------------------------------------------------------------------
+
+  subroutine InitializeP3(mediator, importState, exportState, clock, rc)
+    ! IPDv03p3: realize connected Fields with transfer action "provide"
+    ! and remove Fields that are not connected
+    type(ESMF_GridComp)  :: mediator
+    type(ESMF_State)     :: importState, exportState
+    type(ESMF_Clock)     :: clock
+    integer, intent(out) :: rc
+
+    ! -- begin
+    call NamespaceCheckConnectedFields(rc)
+    
+  end subroutine InitializeP3
+  
+  !-----------------------------------------------------------------------------
+
+  subroutine InitializeP4(mediator, importState, exportState, clock, rc)
+    ! IPDv03p4: optionally modify the decomp/distr of transferred Grid/Mesh
+    type(ESMF_GridComp)  :: mediator
+    type(ESMF_State)     :: importState, exportState
+    type(ESMF_Clock)     :: clock
+    integer, intent(out) :: rc
+
+    ! -- begin
+    call NamespaceAdjustFields(gridComp=mediator, rc=rc)
+
+    print *,'MED: all fields adjusted'
+
+  end subroutine InitializeP4
+    
+  !-----------------------------------------------------------------------------
+
+  subroutine InitializeP5(mediator, importState, exportState, clock, rc)
+    ! IPDv03p5: realize all Fields with transfer action "accept"
+    type(ESMF_GridComp)  :: mediator
+    type(ESMF_State)     :: importState, exportState
+    type(ESMF_Clock)     :: clock
+    integer, intent(out) :: rc
+    
+    ! -- local variables
+    type(ESMF_GeomType_Flag) :: geomtype, localGeomType
+    type(ESMF_Grid)          :: grid, localGrid
+    type(ESMF_Mesh)          :: mesh, localMesh
+    real(ESMF_KIND_R8), dimension(2) :: coordBounds
+
+    integer, parameter :: numLevels = 188
+    real(ESMF_KIND_R8), dimension(numLevels), parameter :: verticalLevels = (/ &
+      0.34, 0.39, 0.44, 0.51, 0.58, 0.66, 0.75, 0.86, 0.97, 1.11, 1.26, &
+      1.42, 1.61, 1.82, 2.05, 2.31, 2.59, 2.91, 3.25, 3.62, 4.03, 4.46, 4.93, &
+      5.42, 5.95, 6.51, 7.09, 7.7, 8.33, 8.99, 9.66, 10.35, 11.04, 11.75, &
+      12.47, 13.2, 13.93, 14.67, 15.42, 16.19, 16.97, 17.76, 18.58, 19.42, &
+      20.27, 21.15, 22.05, 22.97, 23.92, 24.88, 25.87, 26.88, 27.91, 28.96, &
+      30.04, 31.15, 32.29, 33.46, 34.66, 35.9, 37.18, 38.49, 39.85, 41.25, &
+      42.68, 44.15, 45.65, 47.18, 48.74, 50.31, 51.9, 53.49, 55.09, 56.69, &
+      58.29, 59.88, 61.46, 63.03, 64.58, 66.13, 67.66, 69.18, 70.69, 72.2, &
+      73.72, 75.2, 76.69, 78.16, 79.63, 81.1, 82.57, 84.02, 85.48, 86.93, &
+      88.37, 89.81, 91.25, 92.68, 94.11, 95.54, 96.97, 98.41, 99.86, 101.33, &
+      102.83, 104.38, 105.99, 107.66, 109.44, 111.33, 113.36, 115.61, 118.11, &
+      120.92, 124.09, 127.6, 131.47, 135.68, 140.25, 145.17, 150.44, 156.05, &
+      161.98, 168.24, 174.8, 181.66, 188.81, 196.24, 203.93, 211.9, 220.13, &
+      228.61, 237.34, 246.32, 255.54, 265, 274.69, 284.6, 294.72, 305.04, &
+      315.56, 326.27, 337.22, 348.31, 359.6, 371.08, 382.77, 394.69, 406.85, &
+      418, 430, 440, 450, 460, 470, 480, 490, 500, 510, 520, 530, 540, 550, &
+      560, 570, 580, 590, 600, 610, 620, 630, 640, 650, 660, 670, 680, 690, &
+      700, 710, 720, 730, 740, 750, 760, 770, 780, 790, 800 /)
+
+    real(ESMF_KIND_R8),    parameter :: earthRadius = 6371.0088_ESMF_KIND_R8 !  IUGG Earth Mean Radius (Moritz, 2000)
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    ! -- if ATM fields are defined on a mesh, the mesh needs to be replaced
+    ! -- get min/max height from IPE mesh
+    call NamespaceGet("IPM", importState, mesh=mesh, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call MeshGetBounds(mesh, 3, coordBounds, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    write(6,'(" -- InitP5: MeshGetBounds: low/upp = ",2g16.6)') coordBounds
+
+    call NamespaceGet("ATM", importState, geomtype=geomtype, &
+      grid=grid, mesh=mesh, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    if (geomtype == ESMF_GEOMTYPE_GRID) then
+
+      localGrid = GridAddNewCoord(grid, coord=verticalLevels, &
+        scale=1._ESMF_KIND_R8/earthRadius, offset=1._ESMF_KIND_R8, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      call NamespaceSetLocalGrid("ATM", localGrid, rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      print *,'MED: done creating intermediate 3D grid'
+
+    else if (geomtype == ESMF_GEOMTYPE_MESH) then
+
+      call initGrids(mediator, mesh, localMesh, minheight=coordBounds(1), &
+        rc=rc)
+!       heights=verticalLevels, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      call NamespaceUpdateFields("ATM", importState, mesh=mesh, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      call NamespaceSetLocalMesh("ATM", localMesh, rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      print *,'MED: done creating intermediate 3D mesh'
+
+    end if
+   
+    print *,'MED: starting field realize ...'
+    call NamespaceRealizeFields(rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    print *,'MED: done field realize'
+
+  end subroutine InitializeP5
+
+  !-----------------------------------------------------------------------------
+
+  subroutine DataInitialize(mediator, rc)
+    type(ESMF_GridComp)  :: mediator
+    integer, intent(out) :: rc
+    
+    ! -- local variable
+    type(ESMF_State)         :: importState
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    print *,'MED: DataInitialize: calling NamespaceInitializeFields ...'
+    call NamespaceInitializeFields(rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    print *,'MED: DataInitialize: done NamespaceInitializeFields ...'
+
+    ! indicate that data initialization is complete (breaking out of init-loop)
+    print *,'MED: DataInitialize: setting complete attribute...'
+    call NUOPC_CompAttributeSet(mediator, &
+      name="InitializeDataComplete", value="true", rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    print *,'MED: DataInitialize: done complete attribute'
+    print *,'MED: DataInitialize: done'
+    
+  end subroutine DataInitialize
+
+  !-----------------------------------------------------------------------------
+
+  subroutine MediatorAdvance(mediator, rc)
+    type(ESMF_GridComp)  :: mediator
+    integer, intent(out) :: rc
+    
+    ! local variables
+    type(ESMF_Clock)      :: clock
+    type(ESMF_Field)      :: srcField, dstField, tmpField
+    type(ESMF_Array)      :: tmpArray
+    type(ESMF_State)      :: importState, exportState
+    type(ESMF_Time)       :: currTime, stopTime, startTime
+    type(rhType), pointer :: rh
+    integer               :: item
+
+    integer, save :: timeSlice = 1
+
+    real(ESMF_KIND_R8),    parameter :: earthRadius = 6371008.8_ESMF_KIND_R8 !  IUGG Earth Mean Radius (Moritz, 2000)
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    print *,'MED: entering MediatorAdvance...'
+    ! query the Component for its clock, importState and exportState
+    call ESMF_GridCompGet(mediator, clock=clock, &
+      importState=importState, exportState=exportState, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! HERE THE MEDIATOR ADVANCES: currTime -> currTime + timeStep
+    
+    call ESMF_ClockPrint(clock, options="currTime", &
+      preString="------>Advancing Mediator from: ", rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    if (.not.RouteHandleListIsCreated()) then
+#if 0
+      ! -- set intermediate grid from field
+      call NamespaceSetLocalGridFromField("ATM", importState, "average_height", &
+        scale=1._ESMF_KIND_R8/earthRadius, offset=1._ESMF_KIND_R8, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      ! -- then remove field from importState
+      call NamespaceRemoveField("ATM", importState, "average_height", rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+#endif
+      ! -- precompute routehandles
+      call RouteHandleCreate(rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      call RouteHandlePrint(rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+    end if
+
+    print *,'MED: done with routehandle printing'
+    print *,'MED: entering NamespaceSetRemoteLevelsFromField...'
+
+    ! -- identify field providing time-changing vertical levels
+    call NamespaceSetRemoteLevelsFromField("ATM", importState, "height", &
+      scale=1._ESMF_KIND_R8/earthRadius, offset=1._ESMF_KIND_R8, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    print *,'MED: done NamespaceSetRemoteLevelsFromField...'
+    print *,'MED: calling RouteHandleListGet...'
+      
+    rh => RouteHandleListGet(rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    print *,'MED: done RouteHandleListGet...is rh? ', associated(rh)
+
+    ! -- perform necessary computation and regridding
+    do while (associated(rh))
+
+      ! -- Fields from WAM to IPE require special treatment
+      if (trim(rh % label) == "ATM -> IPM") then
+        ! -- vertical profiles of gaseus species must be extrapolated above TOA
+        ! -- extrapolated profiles depend upon neutral temperature at TOA
+        ! -- therefore the neutral temperature field must be retrieved first
+        tmpField = StateGetField(rh % srcState, "temp_neutral", rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+        call ESMF_FieldGet(tmpField, array=tmpArray, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+
+        ! -- only process fields with known destination
+        do item = 1, size(rh % dstState % fieldNames)
+          print *, 'MED: regridding ',trim(rh % dstState % fieldNames(item)), &
+            ' with ', trim(rh % label)
+          ! -- get source field, interpolated to intermediate grid if needed
+!         if (trim(rh % dstState % fieldNames(item)) == "temp_neutral") then
+          if (.false.) then
+            srcField = tmpField
+          else
+            srcField = StateGetField(rh % srcState, &
+              trim(rh % dstState % fieldNames(item)), &
+              auxArray=tmpArray, options=rh % dstState % fieldOptions(item), rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+          end if
+
+          if (timeSlice == 1) then
+            call ESMF_FieldFill(srcField, dataFillScheme="one", rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+          end if
+
+          ! -- get destination field, interpolated to intermediate grid if needed
+          dstField = StateGetField(rh % dstState, &
+            trim(rh % dstState % fieldNames(item)), rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+          ! -- print diagnostic info
+          call FieldPrintMinMax(srcField, "pre  - src:" // trim(rh % dstState % fieldNames(item)), rc)
+          call FieldPrintMinMax(dstField, "pre  - dst:" // trim(rh % dstState % fieldNames(item)), rc)
+          ! -- regrid
+          call ESMF_FieldRegrid(srcField=srcField, dstField=dstField, &
+!           zeroregion=ESMF_REGION_SELECT, &
+            zeroregion=ESMF_REGION_TOTAL, &
+            routehandle=rh % rh, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+          call FieldPrintMinMax(srcField, "post - src:" // trim(rh % dstState % fieldNames(item)), rc)
+          call FieldPrintMinMax(dstField, "post - dst:" // trim(rh % dstState % fieldNames(item)), rc)
+
+#if 0
+          ! -- store source field
+          call StateStoreField(rh % srcState, srcField, &
+            trim(rh % dstState % fieldNames(item)), rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+          ! -- store destination field
+          call StateStoreField(rh % dstState, dstField, &
+            trim(rh % dstState % fieldNames(item)), rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+#endif
+
+        end do
+
+      else
+        ! -- perform standard regridding w/ linear vertical interpolation
+      ! -- only process fields with known destination
+        do item = 1, size(rh % dstState % fieldNames)
+          print *, 'MED: regridding ',trim(rh % dstState % fieldNames(item)), &
+            ' with ', trim(rh % label)
+          call FieldRegrid(rh, trim(rh % dstState % fieldNames(item)), rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+        end do
+
+      end if
+
+      rh => rh % next
+    end do
+
+    timeSlice = timeSlice + 1
+
+  end subroutine MediatorAdvance
+
+  subroutine Finalize(mediator, rc)
+
+    type(ESMF_GridComp)  :: mediator
+    integer, intent(out) :: rc
+
+    ! -- local variables
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    ! -- free up memory
+    call RouteHandlePrint(rc=rc)
+
+    ! -- routehandles
+    call RouteHandleListRelease(rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! -- connected components
+    call NamespaceDestroy(rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    
+  end subroutine Finalize
+
+end module module_MED_SWPC

--- a/NEMS/src/module_MEDIATOR_SWPC.F90
+++ b/NEMS/src/module_MEDIATOR_SWPC.F90
@@ -1,3 +1,4 @@
+#define LEGACY
 module module_MED_SWPC
 
   !-----------------------------------------------------------------------------
@@ -463,8 +464,13 @@ module module_MED_SWPC
 
     if (timeSlice > 1) then
       ! -- identify field providing time-changing vertical levels
+#ifdef LEGACY
+      call NamespaceSetRemoteLevelsFromField("ATM", importState, "height", &
+        scale=1._ESMF_KIND_R8/1000.0, rc=rc)
+#else
       call NamespaceSetRemoteLevelsFromField("ATM", importState, "height", &
         scale=1._ESMF_KIND_R8/earthRadius, offset=1._ESMF_KIND_R8, rc=rc)
+#endif
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, &
         file=__FILE__)) &
@@ -479,7 +485,11 @@ module module_MED_SWPC
           ! -- extrapolated profiles depend upon neutral temperature at TOA
           ! -- therefore the neutral temperature field must be retrieved first
           tmpField = StateGetField(rh % srcState, "temp_neutral", &
+#ifdef LEGACY
+            options="origin", rc=rc)
+#else
             options="native", rc=rc)
+#endif
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
@@ -535,8 +545,8 @@ module module_MED_SWPC
             call FieldPrintMinMax(srcField, "pre  - src:" // trim(rh % dstState % fieldNames(item)), rc)
             ! -- regrid
             call ESMF_FieldRegrid(srcField=srcField, dstField=dstField, &
-!             zeroregion=ESMF_REGION_SELECT, &
-              zeroregion=ESMF_REGION_TOTAL, &
+              zeroregion=ESMF_REGION_SELECT, &
+!             zeroregion=ESMF_REGION_TOTAL, &
               routehandle=rh % rh, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
               line=__LINE__, &

--- a/NEMS/src/module_MEDIATOR_SWPC_methods.F90
+++ b/NEMS/src/module_MEDIATOR_SWPC_methods.F90
@@ -1,0 +1,4942 @@
+module module_MED_SWPC_methods
+
+  !-----------------------------------------------------------------------------
+  ! Mediator Methods
+  !-----------------------------------------------------------------------------
+
+  use ESMF
+  use NUOPC
+  
+  implicit none
+  
+  type stateType
+    type(ESMF_State) :: parent
+    type(ESMF_State) :: self
+    character(len=ESMF_MAXSTR), dimension(:), pointer :: fieldNames
+    character(len=ESMF_MAXSTR), dimension(:), pointer :: fieldOptions
+    character(len=ESMF_MAXSTR) :: trAction
+    type(ESMF_Grid)            :: localGrid
+    type(ESMF_Mesh)            :: localMesh
+    type(ESMF_Field)           :: localField
+    integer                    :: ugDimLength
+    type(ESMF_Array)           :: remoteLevels
+    type(stateType),   pointer :: next 
+  end type stateType
+
+  type compType
+    character(len=ESMF_MAXSTR) :: name
+    type(stateType),   pointer :: stateList
+    type(compType),    pointer :: next
+  end type compType
+
+  type rhType
+    character(len=ESMF_MAXSTR) :: label
+    type(ESMF_RouteHandle)   :: rh
+    type(stateType), pointer :: srcState, dstState
+    type(rhType),    pointer :: next
+  end type rhType
+
+  type (compType), pointer :: compList => null()
+  type (rhType),   pointer :: rhList   => null()
+
+  interface Interpolate
+    module procedure VerticalInterpolate1D
+    module procedure VerticalInterpolate2D
+  end interface Interpolate
+
+
+  private
+
+  public :: &
+    compType, &
+    rhType
+
+  public :: &
+    FieldPrintMinMax,                  &
+    FieldRegrid,                       &
+    GridAddNewCoord,                   &
+    initGrids,                         &
+    MeshAddNewCoord,                   &
+    MeshGetBounds,                     &
+    NamespaceAdd,                      &
+    NamespaceAdjustFields,             &
+    NamespaceAdvertise,                &
+    NamespaceCheckConnectedFields,     &
+    NamespaceDestroy,                  &
+    NamespaceGet,                      &
+    NamespaceGetGrid,                  &
+    NamespaceGetLocal,                 &
+    NamespaceInitializeFields,         &
+    NamespacePrint,                    &
+    NamespaceRealizeFields,            &
+    NamespaceRemoveField,              &
+    NamespaceSetLocalGrid,             &
+    NamespaceSetLocalGridFromField,    &
+    NamespaceSetLocalMesh,             &
+    NamespaceSetRemoteLevelsFromField, &
+    NamespaceUpdateFields,             &
+    RouteHandleCreate,                 &
+    RouteHandleListGet,                &
+    RouteHandleListIsCreated,          &
+    RouteHandleListRelease,            &
+    RouteHandlePrint,                  &
+    StateGetField,                     &
+    StateStoreField
+  
+contains
+
+  ! -- Namespace: Add(Create)/Remove objects/Destroy: begin definition --
+  
+  subroutine NamespaceAdd(name, state, fieldNames, trAction, ungriddedVerticalDim, fieldOptions, rc)
+    character(len=*),               intent(in) :: name
+    type(ESMF_State)                           :: state
+    character(len=*), dimension(:), intent(in) :: fieldNames
+    character(len=*),               intent(in) :: trAction
+    logical,             optional,  intent(in) :: ungriddedVerticalDim
+    character(len=*), dimension(:), optional, intent(in) :: fieldOptions
+    integer,             optional, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p, q
+    type(stateType), pointer :: compState, s
+    integer :: localrc
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    nullify(compState, p, q, s)
+
+    p => compList
+    q => compList
+    do while (associated(p))
+      if (trim(p % name) == name) exit
+      q => p
+      p => p % next
+    end do
+
+    if (.not.associated(p)) then
+      allocate(p, stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      p % name = name
+      nullify(p % next, p % stateList)
+      if (associated(q)) then
+        q % next => p
+      else
+        q => p
+        compList => p
+      end if
+    end if
+
+    call StateAdd(compState, state, fieldNames, trAction, &
+      ungriddedVerticalDim=ungriddedVerticalDim, &
+      fieldOptions=fieldOptions, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    if (associated(p % stateList)) then
+      s => p % stateList
+      do while (associated(s % next))
+        s => s % next
+      end do
+      s % next => compState
+    else
+      p % stateList => compState
+    end if
+
+    nullify(p, q, s, compState)
+     
+  end subroutine NamespaceAdd
+
+  subroutine StateAdd(s, state, fieldNames, trAction, ungriddedVerticalDim, fieldOptions, rc)
+    type(stateType),                   pointer :: s
+    type(ESMF_State)                           :: state
+    character(len=*), dimension(:), intent(in) :: fieldNames
+    character(len=*),               intent(in) :: trAction
+    logical,             optional,  intent(in) :: ungriddedVerticalDim
+    character(len=*), dimension(:), optional, intent(in) :: fieldOptions
+    integer,             optional, intent(out) :: rc
+
+    ! -- local variables
+    integer :: localrc, fieldCount, totalCount, ugDimLength
+    character(len=ESMF_MAXSTR), dimension(:), allocatable :: tmp
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    ugDimLength = 0
+    if (present(ungriddedVerticalDim)) then
+      if (ungriddedVerticalDim) ugDimLength = -1
+    end if
+
+    if (present(fieldOptions)) then
+      if (size(fieldNames) /= size(fieldOptions)) then
+        call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+          msg="number of field options must match number of fields", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+          return ! bail out
+      end if
+    end if
+
+    if (.not.associated(s)) then
+      allocate(s, stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+    end if
+    if (associated(s % fieldNames)) then
+      if (trim(s % trAction) /= trAction) then
+        ! -- add fields to same nested state (only one value of trAction is allowed)
+        call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+          msg="transferAction must match when adding fields to same state", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+          return ! bail out
+      end if 
+      if ((s % ugDimLength * ugDimLength == 0) .and. &
+          (s % ugDimLength /= ugDimLength)) then
+        ! -- add fields to same nested state (only one value of trAction is allowed)
+        call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+          msg="field to be added must have ungridded dimension length", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+          return ! bail out
+      end if 
+      fieldCount = size(s % fieldNames)
+      totalCount = fieldCount + size(fieldNames)
+      allocate(tmp(fieldCount), stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      tmp(1:fieldCount) = s % fieldNames
+      deallocate(s % fieldNames, stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      allocate(s % fieldNames(totalCount), stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      s % fieldNames(1:fieldCount)      = tmp
+      s % fieldNames(fieldCount + 1:)   = fieldNames
+      tmp(1:fieldCount) = s % fieldOptions
+      deallocate(s % fieldOptions, stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      allocate(s % fieldOptions(totalCount), stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      s % fieldOptions(1:fieldCount)      = tmp
+      s % fieldOptions(fieldCount + 1:)   = fieldOptions
+      deallocate(tmp, stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+    else
+      allocate(s % fieldNames(size(fieldNames)), &
+               s % fieldOptions(size(fieldNames)), stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      s % fieldNames      = fieldNames
+      s % ugDimLength     = ugDimLength
+      s % trAction        = trAction
+      if (present(fieldOptions)) then
+        s % fieldOptions  = fieldOptions
+      else
+        s % fieldOptions  = "none"
+      end if
+    end if
+    s % parent = state
+    nullify(s % next)
+
+  end subroutine StateAdd
+
+  subroutine NamespaceRemoveField(name, state, fieldName, rc)
+
+    character(len=*), intent(in) :: name
+    type(ESMF_State)             :: state
+    character(len=*), intent(in) :: fieldName
+    integer,         intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+    integer                  :: item, itemCount, itemFound, localrc
+    character(len=ESMF_MAXSTR), dimension(:), allocatable :: tmp
+      
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    itemFound = 0
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == name) then
+        s => p % stateList
+        do while (associated(s))
+          if (s % parent == state) then
+            if (associated(s % fieldNames)) then
+              itemCount = size(s % fieldNames)
+              do item = 1, itemCount
+                if (trim(s % fieldNames(item)) == fieldName) then
+                  itemFound = item
+                  exit
+                end if
+              end do
+              if (itemFound > 0) then
+                if (itemCount == 1) then
+                  deallocate(s % fieldNames, s % fieldOptions, stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return
+                  nullify(s % fieldNames)
+                  nullify(s % fieldOptions)
+                else
+                  itemCount = itemCount - 1
+                  allocate(tmp(itemCount), stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return
+                  tmp(1:itemFound-1) = s % fieldNames(1:itemFound-1)
+                  tmp(itemFound:) = s % fieldNames(itemFound+1:)
+                  deallocate(s % fieldNames, stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return
+                  allocate(s % fieldNames(itemCount), stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return
+                  s % fieldNames = tmp
+                  tmp(1:itemFound-1) = s % fieldOptions(1:itemFound-1)
+                  tmp(itemFound:) = s % fieldOptions(itemFound+1:)
+                  deallocate(s % fieldOptions, stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return
+                  allocate(s % fieldOptions(itemCount), stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return
+                  s % fieldOptions = tmp
+                  deallocate(tmp, stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return
+                end if
+                call ESMF_StateRemove(s % self, (/ fieldName /), rc=rc)
+                if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+                  line=__LINE__, &
+                  file=__FILE__)) &
+                  return  ! bail out
+                return
+              end if
+            end if
+          end if
+          s => s % next
+        end do
+        exit
+      end if
+      p => p % next
+    end do
+
+  end subroutine NamespaceRemoveField
+
+  ! -- Namespace: Add(Create)/Remove objects/Destroy: end definition --
+
+  ! -- Namespace: coupling actions Advertise/Connect/Realize/Initialize: begin definition --
+
+  ! -- Private methods
+  subroutine AdjustFieldGeometry(state, fieldName, petCount, rc)
+
+      type(ESMF_State)              :: state
+      character(len=*), intent(in)  :: fieldName
+      integer,          intent(in)  :: petCount
+      integer,          intent(out) :: rc
+
+      ! -- local variables
+      type(ESMF_Field)           :: field
+      type(ESMF_DistGrid)        :: distgrid
+      type(ESMF_Grid)            :: grid
+      type(ESMF_Mesh)            :: mesh
+      type(ESMF_GeomType_flag)   :: geomtype
+      integer                    :: item, deCount, dimCount, tileCount, localrc
+      integer, dimension(:,:), allocatable :: minIndexPTile, maxIndexPTile
+      character(len=ESMF_MAXSTR) :: transferAction
+
+      integer                    :: i, j
+      integer, dimension(:,:), allocatable :: regDecompPTile
+      integer, dimension(:), allocatable :: deToTileMap
+      real(ESMF_KIND_R8), dimension(:,:), pointer :: p  !!!!!! TEST
+      ! -- begin
+      rc = ESMF_SUCCESS
+
+      call ESMF_StateGet(state, field=field, &
+        itemName=fieldName, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      call NUOPC_GetAttribute(field, name="TransferActionGeomObject", &
+        value=transferAction, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      if (trim(transferAction)=="accept") then
+        ! the Connector instructed the Mediator to accept geom object
+        ! -> find out which type geom object the field holds
+        call ESMF_FieldGet(field, geomtype=geomtype, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+
+        if (geomtype == ESMF_GEOMTYPE_GRID) then
+
+          ! empty field holds a Grid with DistGrid
+          call ESMF_FieldGet(field, grid=grid, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          ! access the DistGrid
+          call ESMF_GridGet(grid, distgrid=distgrid, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+        else if (geomtype == ESMF_GEOMTYPE_MESH) then
+
+          ! empty field holds a Grid with DistGrid
+          call ESMF_FieldGet(field, mesh=mesh, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          ! access the DistGrid
+          call ESMF_MeshGet(mesh, elementDistgrid=distgrid, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+        else
+
+          call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+            msg="Unsupported geom object found in "// fieldName, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)
+          return ! bail out
+
+        end if
+
+        ! get DE count
+        call ESMF_DistGridGet(distgrid, deCount=deCount, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+
+        if (deCount /= petCount) then
+          ! Create a custom DistGrid, based on the minIndex, maxIndex of the 
+          ! accepted DistGrid, but with a default regDecomp for the current VM
+          ! that leads to 1DE/PET.
+          ! get dimCount and tileCount
+          call ESMF_DistGridGet(distgrid, dimCount=dimCount, deCount=deCount, &
+            tileCount=tileCount, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+          allocate(minIndexPTile(dimCount, tileCount), &
+            maxIndexPTile(dimCount, tileCount), stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+
+          ! get minIndex and maxIndex arrays
+          call ESMF_DistGridGet(distgrid, minIndexPTile=minIndexPTile, &
+            maxIndexPTile=maxIndexPTile, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+          write(6,'("--- Adjust field geom: ",a)') trim(fieldName)
+          write(6,'("--- Adjust field geom: get deCount = ",i8," dimCount = ",i8," tileCount = ",i8)') deCount, dimCount, tileCount
+          write(6,'("--- Adjust field geom: get minIndexPTile = ",10i12)') minIndexPTile
+          write(6,'("--- Adjust field geom: get maxIndexPTile = ",10i12)') maxIndexPTile
+
+          allocate(regDecompPTile(dimCount,tileCount))
+          regDecompPTile = 0
+          do i = 0, max(petCount, tileCount) -1
+            j = mod(i, tileCount) + 1
+            regDecompPTile(1, j) = regDecompPTile(1, j) + 1
+          end do
+          regDecompPTile(2:,:) = 1
+
+          ! create the new DistGrid with the same minIndexPTile and maxIndexPTile,
+          ! but with a default regDecompPTile
+          distgrid = ESMF_DistGridCreate(minIndexPTile=minIndexPTile, &
+            maxIndexPTile=maxIndexPTile, regDecompPTile=regDecompPTile, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+
+          !------- TEST BEGIN
+          call ESMF_DistGridGet(distgrid, deCount=j, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          allocate(deToTileMap(j))
+          deToTileMap = 0
+          call ESMF_DistGridGet(distgrid, deToTileMap=deToTileMap, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          write(6,'("--- Adjust field DistGrid: deToTileMap    = ",10i12)') deToTileMap
+          do i = 1, tileCount
+            write(6,'("--- Adjust field DistGrid: regDecompPTile = ",10i12)') regDecompPTile(:,i)
+          end do
+          deallocate(deToTileMap)
+          !------- TEST END
+
+          deallocate(regDecompPTile)
+
+          if (geomtype == ESMF_GEOMTYPE_GRID) then
+
+            ! Create a new Grid on the new DistGrid and swap it in the Field
+            grid = ESMF_GridCreate(distgrid, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            call ESMF_FieldEmptySet(field, grid=grid, rc=rc)    
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+
+          else if (geomtype == ESMF_GEOMTYPE_MESH) then
+
+            ! Create a new Grid on the new DistGrid and swap it in the Field
+            mesh = ESMF_MeshCreate(distgrid, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            call ESMF_FieldEmptySet(field, mesh=mesh, rc=rc)    
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+
+          end if
+
+          ! local clean-up
+          deallocate(minIndexPTile, maxIndexPTile, stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+
+        end if
+
+      end if
+
+  end subroutine AdjustFieldGeometry
+    
+  subroutine RealizeFieldGeometry(s, fieldName, rc)
+
+      type(stateType), intent(inout) :: s
+      character(len=*),   intent(in) :: fieldName
+      integer,           intent(out) :: rc
+
+      ! -- local variables
+      type(ESMF_Field)               :: field
+      type(ESMF_FieldStatus_flag)    :: fieldStatus
+      integer                        :: itemCount, localrc
+      integer, dimension(:), pointer :: ugLBound, ugUBound, gridToFieldMap
+
+      print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - entering ...'
+      ! -- retrieve field object
+      call ESMF_StateGet(s % self, field=field, itemName=trim(fieldName), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - checking status ...'
+      ! -- check field status
+      call ESMF_FieldGet(field, status=fieldStatus, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      if (fieldStatus == ESMF_FIELDSTATUS_GRIDSET) then
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - status is GRIDSET'
+        ! the Connector instructed the Mediator to accept geom object
+        ! the transferred geom object is already set, allocate memory 
+        ! for data by complete
+        nullify(ugLBound, ugUBound, gridToFieldMap)
+        ! deal with gridToFieldMap
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - getting gridToFieldMap...'
+        call ESMF_AttributeGet(field, name="GridToFieldMap", &
+          convention="NUOPC", purpose="Instance", &
+          itemCount=itemCount, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - gridToFieldMap itemCount = ',itemCount
+        if (itemCount > 0) then
+          allocate(gridToFieldMap(itemCount), stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+          call ESMF_AttributeGet(field, name="GridToFieldMap", &
+            convention="NUOPC", purpose="Instance", &
+            valueList=gridToFieldMap, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+        endif
+        ! deal with ungriddedLBound
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - getting UngriddedLBound...'
+        call ESMF_AttributeGet(field, name="UngriddedLBound", &
+          convention="NUOPC", purpose="Instance", &
+          itemCount=itemCount, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - UngriddedLBound itemCount = ',itemCount
+        if (itemCount > 0) then
+          if (s % ugDimLength < 0 .and. itemCount > 1) then
+            call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+              msg="Field "//fieldName//" must have ONE ungridded dimension!", &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)
+            return  ! bail out
+          end if
+          if (s % ugDimLength == 0) then
+            call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+              msg="Field "//fieldName//" must have NO ungridded dimensions!", &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)
+            return  ! bail out
+          end if
+          allocate(ugLBound(itemCount), stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+          call ESMF_AttributeGet(field, name="UngriddedLBound", &
+            convention="NUOPC", purpose="Instance", &
+            valueList=ugLBound, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+        end if
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - done UngriddedLBound'
+        ! deal with ungriddedUBound
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - getting UngriddedUBound...'
+        call ESMF_AttributeGet(field, name="UngriddedUBound", &
+          convention="NUOPC", purpose="Instance", &
+          itemCount=itemCount, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+        if (itemCount > 0) then
+          if (s % ugDimLength < 0 .and. itemCount > 1) then
+            call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+              msg="Field "//fieldName//" must have ONE ungridded dimension!", &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)
+            return  ! bail out
+          end if
+          if (s % ugDimLength == 0) then
+            call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+              msg="Field "//fieldName//" must have NO ungridded dimensions!", &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)
+            return  ! bail out
+          end if
+          allocate(ugUBound(itemCount), stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+          call ESMF_AttributeGet(field, name="UngriddedUBound", &
+            convention="NUOPC", purpose="Instance", &
+            valueList=ugUBound, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          if (s % ugDimLength < 0) then
+            s % ugDimLength = ugUBound(1) - ugLBound(1) + 1
+          else if (s % ugDimLength /= ugUBound(1) - ugLBound(1) + 1) then
+            call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+              msg="Field "//fieldName//" ungridded dimension has wrong length.", &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)
+            return  ! bail out
+          end if
+        end if
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - done UngriddedUBound'
+
+        print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - completing field...'
+        if (associated(ugLBound) .and. associated(ugUBound)) then
+          print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - ugL/U'
+          if (associated(gridToFieldMap)) then
+            call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
+              ungriddedLBound=ugLBound, ungriddedUBound=ugUBound, &
+              gridToFieldMap=gridToFieldMap, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+          else
+            call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
+              ungriddedLBound=ugLBound, ungriddedUBound=ugUBound, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+          end if
+          deallocate(ugLBound, ugUBound, stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+        else
+          print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - no ugL/U', associated(gridToFieldMap)
+          if (associated(gridToFieldMap)) then
+            print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - no ugL/U, with map...'
+            call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
+              gridToFieldMap=gridToFieldMap, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - no ugL/U, with map - DONE'
+          else
+            print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - no ugL/U, no map...'
+            call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - no ugL/U, no map - DONE'
+          end if
+          print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - no ugL/U - DONE'
+        end if
+
+        if (associated(ugLBound)) then
+          deallocate(ugLBound, stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+        end if
+
+        if (associated(ugUBound)) then
+          deallocate(ugUBound, stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+        end if
+
+        if (associated(gridToFieldMap)) then
+          deallocate(gridToFieldMap, stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return
+        end if
+
+      end if
+      print *,'--RealizeFieldGeometry: '//trim(fieldName)//' - EXIT'
+      
+  end subroutine RealizeFieldGeometry
+
+  ! -- Public methods
+
+  subroutine NamespaceAdvertise(rc)
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    nullify(p, s)
+
+    p => compList
+    do while (associated(p))
+      s => p % stateList
+      do while (associated(s))
+        call NUOPC_AddNamespace(s % parent, namespace=trim(p % name), &
+          nestedState=s % self, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__)) &
+          return
+        call NUOPC_Advertise(s % self, StandardNames=s % fieldNames, &
+          TransferOfferGeomObject=trim(s % trAction), rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__)) &
+          return
+        s => s % next
+      end do
+      p => p % next
+    end do
+
+    nullify(p, s)
+      
+  end subroutine NamespaceAdvertise
+
+  subroutine NamespaceCheckConnectedFields(rc)
+
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    type (ESMF_Field)          :: field
+    type (compType),  pointer  :: p
+    type (stateType), pointer  :: s
+    character(len=ESMF_MAXSTR) :: stateName
+    character(len=ESMF_MAXSTR) :: connectedValue, transferAction
+    integer :: item
+    
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    nullify(p, s)
+
+    p => compList
+    do while (associated(p))
+      s => p % stateList
+      do while (associated(s))
+        do item = 1, size(s % fieldNames)
+          call ESMF_StateGet(s % self, field=field, &
+            itemName=trim(s % fieldNames(item)), rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          call NUOPC_GetAttribute(field, name="Connected", &
+            value=connectedValue, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          if (trim(connectedValue) == "false") then
+            call ESMF_StateGet(s % self, name=stateName, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            call ESMF_LogSetError(ESMF_RC_NOT_FOUND, &
+              msg="Field "//trim(p % name)//"/"//trim(s % fieldNames(item)) &
+              //" in State "//trim(stateName)//" is not connected.", &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)
+            return ! bail out
+          else
+            call NUOPC_GetAttribute(field, name="TransferActionGeomObject", &
+              value=transferAction, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            if (trim(transferAction)=="provide") then
+              ! the Connector instructed the Mediator to provide geom object
+              call ESMF_StateGet(s % self, name=stateName, rc=rc)
+              if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__, &
+                file=__FILE__)) &
+                return  ! bail out
+              call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+                msg="Cannot fulfill request to provide geom object for "// &
+                trim(s % fieldNames(item))//" in State "//trim(stateName), &
+                line=__LINE__, &
+                file=__FILE__, &
+                rcToReturn=rc)
+              return ! bail out
+            end if
+          end if
+        end do
+        s => s % next
+      end do
+      p => p % next
+    end do
+    
+  end subroutine NamespaceCheckConnectedFields
+
+  subroutine NamespaceAdjustFields(gridComp, rc) 
+    type(ESMF_GridComp), optional              :: gridComp
+    integer,             optional, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+    type(ESMF_VM)            :: vm
+    integer                  :: item, petCount
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    ! -- get number of PET for current gridded component, if present
+    if (present(gridComp)) then
+
+      ! -- get VM for gridded component
+      call ESMF_GridCompGet(gridComp, vm=vm, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+      ! -- retrieve PET information
+      call ESMF_VMGet(vm, petCount=petCount, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+
+    else
+
+      petCount = -1
+
+    end if
+
+    p => compList
+    nullify(s)
+    do while (associated(p))
+      s => p % stateList
+      do while (associated(s))
+        do item = 1, size(s % fieldNames)
+          call AdjustFieldGeometry(s % self, trim(s % fieldNames(item)), &
+            petCount, rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          print *,'MED: done adjusting with geom ',trim(s % fieldNames(item))
+        end do
+        s => s % next
+      end do
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+  end subroutine NamespaceAdjustFields
+
+  subroutine NamespaceUpdateFields(name, state, grid, mesh, rc)
+    character(len=*),          intent(in)  :: name
+    type(ESMF_State),          intent(in)  :: state
+    type(ESMF_Grid), optional, intent(in)  :: grid
+    type(ESMF_Mesh), optional, intent(in)  :: mesh
+    integer,         optional, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+    type(ESMF_Field)         :: field
+    logical                  :: isGeom
+    integer                  :: item, localrc
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(grid).or.present(mesh)) then
+      p => compList
+      nullify(s)
+      do while (associated(p))
+        if (trim(p % name) == name) then
+          s => p % stateList
+          do while (associated(s))
+            if (s % parent == state) then
+              do item = 1, size(s % fieldNames)
+                call ESMF_StateGet(s % self, field=field, &
+                  itemName=trim(s % fieldNames(item)), rc=localrc)
+                if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                  line=__LINE__, &
+                  file=__FILE__,  &
+                  rcToReturn=rc)) &
+                  return  ! bail out
+                if (present(grid)) then
+                  call ESMF_FieldEmptySet(field, grid=grid, rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__,  &
+                    rcToReturn=rc)) &
+                    return  ! bail out
+                else if (present(mesh)) then
+                  call ESMF_FieldEmptySet(field, mesh=mesh, rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__,  &
+                    rcToReturn=rc)) &
+                    return  ! bail out
+                end if
+              end do
+            end if
+            s => s % next
+          end do
+        end if
+        p => p % next
+      end do
+    else
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="No Grid or Mesh object provided", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+  end subroutine NamespaceUpdateFields
+
+  subroutine NamespaceRealizeFields(rc)
+    integer, intent(out) :: rc
+
+    ! -- local variable
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+    integer :: item
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    print *,'--NamespaceRealizeFields: entering ...'
+
+    p => compList
+    nullify(s)
+    do while (associated(p))
+      print *,'--NamespaceRealizeFields: name = '//trim(p%name)
+      s => p % stateList
+      do while (associated(s))
+        print *,'--NamespaceRealizeFields: name = '//trim(p%name)//': accessing state...', associated(s % fieldNames)
+        do item = 1, size(s % fieldNames)
+          print *,'MED: realizing with geom ',trim(s % fieldNames(item))
+          call RealizeFieldGeometry(s, trim(s % fieldNames(item)), rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+          print *,'MED: done realizing with geom ',trim(s % fieldNames(item))
+        end do
+        s => s % next
+      end do
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+    print *,'--NamespaceRealizeFields: exiting '
+
+  end subroutine NamespaceRealizeFields
+
+  subroutine NamespaceInitializeFields(value, rc)
+
+    real(ESMF_KIND_R8), optional,  intent(in) :: value
+    integer,            optional, intent(out) :: rc
+    
+    ! -- local variables
+    integer                     :: localrc, item, rank
+    type(compType),     pointer :: p
+    type(stateType),    pointer :: s
+    real(ESMF_KIND_R8), pointer :: fptr1d(:), fptr2d(:,:), fptr3d(:,:,:)
+    real(ESMF_KIND_R8)          :: initValue
+    type(ESMF_Field)            :: field
+    type(ESMF_StateIntent_flag) :: stateIntent
+
+    real(ESMF_KIND_R8), parameter :: defaultInitValue = 0._ESMF_KIND_R8
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    initValue = defaultInitValue
+    if (present(value)) initValue = value
+
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      s => p % stateList
+      do while (associated(s))
+
+        call ESMF_StateGet(s % parent, stateintent=stateIntent, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) &
+          return  ! bail out
+
+        do item = 1, size(s % fieldNames)
+
+          call ESMF_StateGet(s % self, field=field, &
+            itemName=trim(s % fieldNames(item)), rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__,  &
+            file=__FILE__,  &
+            rcToReturn=rc)) &
+            return  ! bail out
+
+#if 0
+          call ESMF_FieldGet(field, rank=rank, rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__,  &
+            file=__FILE__,  &
+            rcToReturn=rc)) &
+            return  ! bail out
+
+          print *,'MED: initializing field ',trim(s % fieldNames(item)), ' w/ dims = ',rank
+
+          select case (rank)
+            case(1)
+              call ESMF_FieldGet(field, farrayPtr=fptr1d, rc=localrc)
+              if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__,  &
+                file=__FILE__,  &
+                rcToReturn=rc)) &
+                return  ! bail out
+              fptr1d = initValue
+            case(2)
+              call ESMF_FieldGet(field, farrayPtr=fptr2d, rc=localrc)
+              if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__,  &
+                file=__FILE__,  &
+                rcToReturn=rc)) &
+                return  ! bail out
+              fptr2d = initValue
+            case(3)
+              call ESMF_FieldGet(field, farrayPtr=fptr3d, rc=localrc)
+              if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__,  &
+                file=__FILE__,  &
+                rcToReturn=rc)) &
+                return  ! bail out
+              fptr3d = initValue
+            case default
+              call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+                msg="Invalid dimensions for field "//trim(s % fieldNames(item)), &
+                line=__LINE__, &
+                file=__FILE__, &
+                rcToReturn=rc)
+                return ! bail out
+          end select
+
+#endif
+          ! --- mark as updated only if in export state??
+          if (stateIntent == ESMF_STATEINTENT_EXPORT) then
+            call NUOPC_SetAttribute(field, name="Updated", value="true", rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__,  &
+              file=__FILE__,  &
+              rcToReturn=rc)) &
+              return  ! bail out
+          end if
+
+        end do
+        s => s % next
+      end do
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+  end subroutine NamespaceInitializeFields
+  
+  subroutine NamespaceDestroy(nsList, rc)
+
+    type(compType), optional, pointer     :: nsList
+    integer,        optional, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p, q
+    type(stateType), pointer :: s, r
+    integer                  :: localrc
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (present(nsList)) then
+      p => nsList
+    else
+      p => compList
+    end if
+
+    ! -- connected components
+    do while (associated(p))
+      q => p
+      p => p % next
+      s => q % stateList
+      do while (associated(s))
+        r => s
+        s => s % next
+        if (associated(r % fieldNames)) then
+          deallocate(r % fieldNames, stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return ! bail out
+          nullify(r % fieldNames)
+        end if
+        if (associated(r % fieldOptions)) then
+          deallocate(r % fieldOptions, stat=localrc)
+          if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)) return ! bail out
+          nullify(r % fieldOptions)
+        end if
+        deallocate(r, stat=localrc)
+        if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)) return ! bail out
+        nullify(r)
+      end do
+      deallocate(q, stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return ! bail out
+      nullify(q)
+    end do
+
+    if (present(nsList)) then
+      nullify(nsList)
+    else
+      nullify(compList)
+    end if
+    
+  end subroutine NamespaceDestroy
+
+  ! -- Namespace: coupling actions Advertise/Connect/Realize/Adjust/Initialize: end definition --
+
+  ! -- Namespace: Create/Get/Set methods: begin definition --
+
+  function NamespaceGetList(rc)
+    integer, optional, intent(out) :: rc
+    type(compType),        pointer :: NamespaceGetList
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    NamespaceGetList => compList
+
+  end function NamespaceGetList
+
+  subroutine NamespaceSetList(nsList, rc)
+    integer, optional, intent(out) :: rc
+    type(compType),        pointer :: nsList
+
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    compList => nsList
+
+  end subroutine NamespaceSetList
+
+  function NamespaceGetField(name, state, fieldName, rc)
+    ! -- input variables
+    character(len=*),   intent(in) :: name
+    type(ESMF_State),   intent(in) :: state
+    character(len=*),   intent(in) :: fieldName
+    integer, optional, intent(out) :: rc
+
+    ! -- output variables
+    type(ESMF_Field)               :: NamespaceGetField
+
+    ! -- local variables
+    integer                  :: item, localrc
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_RC_NOT_FOUND
+
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == trim(name)) then
+        s => p % stateList
+        do while (associated(s))
+          if (s % parent == state) then
+            if (associated(s % fieldNames)) then
+              do item = 1, size(s % fieldNames) 
+                if (trim(s % fieldNames(item)) == trim(fieldName)) then
+                  call ESMF_StateGet(s % self, itemName=trim(fieldName), &
+                    field=NamespaceGetField, rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return  ! bail out
+                  if (present(rc)) rc = ESMF_SUCCESS
+                  return
+                end if
+              end do
+            end if
+          end if
+          s => s % next
+        end do
+      end if
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+  end function NamespaceGetField
+
+  subroutine NamespaceGet(name, state, geomtype, grid, mesh, rc)
+    character(len=*),                    intent(in) :: name
+    type(ESMF_State),                    intent(in) :: state
+    type(ESMF_GeomType_Flag), optional, intent(out) :: geomtype
+    type(ESMF_Grid),          optional, intent(out) :: grid
+    type(ESMF_Mesh),          optional, intent(out) :: mesh
+    integer, optional, intent(out) :: rc
+
+    ! -- local variables
+    integer                     :: localrc
+    type(compType),     pointer :: p
+    type(stateType),    pointer :: s
+    type(ESMF_Field)            :: field
+    type(ESMF_Grid)             :: localGrid
+    type(ESMF_Mesh)             :: localMesh
+    type(ESMF_GeomType_Flag)    :: localGeomType
+    type(ESMF_FieldStatus_Flag) :: fieldStatus
+
+    ! -- begin
+    localrc = ESMF_RC_NOT_FOUND
+    if (present(rc)) rc = ESMF_RC_NOT_FOUND
+
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == trim(name)) then
+        s => p % stateList
+        do while (associated(s))
+          if (s % parent == state) then
+            if (associated(s % fieldNames)) then
+              if (size(s % fieldNames) > 0) then
+                call ESMF_StateGet(s % self, itemName=trim(s % fieldNames(1)), &
+                  field=field, rc=localrc)
+                if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                  line=__LINE__, &
+                  file=__FILE__, &
+                  rcToReturn=rc)) return  ! bail out
+              end if
+            end if
+          end if
+          s => s % next
+        end do
+      end if
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+    if (localrc == ESMF_RC_NOT_FOUND) then
+      call ESMF_LogSetError(localrc, &
+        msg="No field found in namespace "//trim(name), &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field is completed
+    call ESMF_FieldGet(field, status=fieldStatus, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    if (fieldStatus /= ESMF_FIELDSTATUS_COMPLETE .and. &
+        fieldStatus /= ESMF_FIELDSTATUS_GRIDSET) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Field has not been completely created.", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field contains valid grid object
+    call ESMF_FieldGet(field, geomtype=localGeomType, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    if (present(geomtype)) geomtype = localGeomType
+
+    if (localGeomType == ESMF_GEOMTYPE_GRID) then
+      if (present(grid)) then
+        ! -- get grid from field
+        call ESMF_FieldGet(field, grid=grid, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)) return  ! bail out
+      end if
+    else if (localGeomType == ESMF_GEOMTYPE_MESH) then
+      if (present(mesh)) then
+        ! -- get mesh from field
+        call ESMF_FieldGet(field, mesh=mesh, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)) return  ! bail out
+      end if
+    end if
+
+    ! -- return grid object
+    if (present(rc)) rc = ESMF_SUCCESS
+    
+  end subroutine NamespaceGet
+
+  function NamespaceGetGrid(name, state, rc)
+    character(len=*),   intent(in) :: name
+    type(ESMF_State)               :: state
+    integer, optional, intent(out) :: rc
+
+    type(ESMF_Grid) :: NamespaceGetGrid
+
+    ! -- local variables
+    integer                     :: localrc
+    type(compType),     pointer :: p
+    type(stateType),    pointer :: s
+    type(ESMF_Field)            :: field
+    type(ESMF_Grid)             :: grid
+    type(ESMF_GeomType_Flag)    :: geomtype
+    type(ESMF_FieldStatus_Flag) :: fieldStatus
+
+    ! -- begin
+    localrc = ESMF_RC_NOT_FOUND
+    if (present(rc)) rc = ESMF_RC_NOT_FOUND
+
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == trim(name)) then
+        s => p % stateList
+        do while (associated(s))
+          if (s % parent == state) then
+            if (associated(s % fieldNames)) then
+              if (size(s % fieldNames) > 0) then
+                call ESMF_StateGet(s % self, itemName=trim(s % fieldNames(1)), &
+                  field=field, rc=localrc)
+                if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                  line=__LINE__, &
+                  file=__FILE__, &
+                  rcToReturn=rc)) return  ! bail out
+              end if
+            end if
+          end if
+          s => s % next
+        end do
+      end if
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+    if (localrc == ESMF_RC_NOT_FOUND) then
+      call ESMF_LogSetError(localrc, &
+        msg="Field not found.", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field is completed
+    call ESMF_FieldGet(field, status=fieldStatus, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    if (fieldStatus /= ESMF_FIELDSTATUS_COMPLETE) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Field has not been completely created.", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field contains valid grid object
+    call ESMF_FieldGet(field, geomtype=geomtype, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    if (geomtype /= ESMF_GEOMTYPE_GRID) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="No Grid object found in field ", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- get grid from field
+    call ESMF_FieldGet(field, grid=grid, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    ! -- return grid object
+    if (present(rc)) rc = ESMF_SUCCESS
+    NamespaceGetGrid = grid
+    
+  end function NamespaceGetGrid
+!------------------------------------------------------------------------------
+
+  function NamespaceGetMesh(name, state, rc)
+    character(len=*),   intent(in) :: name
+    type(ESMF_State)               :: state
+    integer, optional, intent(out) :: rc
+
+    type(ESMF_Mesh) :: NamespaceGetMesh
+
+    ! -- local variables
+    integer                     :: localrc
+    type(compType),     pointer :: p
+    type(stateType),    pointer :: s
+    type(ESMF_Field)            :: field
+    type(ESMF_Mesh)             :: mesh
+    type(ESMF_GeomType_Flag)    :: geomtype
+    type(ESMF_FieldStatus_Flag) :: fieldStatus
+
+    ! -- begin
+    localrc = ESMF_RC_NOT_FOUND
+    if (present(rc)) rc = ESMF_RC_NOT_FOUND
+
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == trim(name)) then
+        s => p % stateList
+        do while (associated(s))
+          if (s % parent == state) then
+            if (associated(s % fieldNames)) then
+              if (size(s % fieldNames) > 0) then
+                call ESMF_StateGet(s % self, itemName=trim(s % fieldNames(1)), &
+                  field=field, rc=localrc)
+                if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                  line=__LINE__, &
+                  file=__FILE__, &
+                  rcToReturn=rc)) return  ! bail out
+              end if
+            end if
+          end if
+          s => s % next
+        end do
+      end if
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+    if (localrc == ESMF_RC_NOT_FOUND) then
+      call ESMF_LogSetError(localrc, &
+        msg="Field not found.", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field is completed
+    call ESMF_FieldGet(field, status=fieldStatus, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    if (fieldStatus /= ESMF_FIELDSTATUS_COMPLETE) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Field has not been completely created.", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field contains valid mesh object
+    call ESMF_FieldGet(field, geomtype=geomtype, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    if (geomtype /= ESMF_GEOMTYPE_MESH) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="No Mesh object found in field ", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- get mesh from field
+    call ESMF_FieldGet(field, mesh=mesh, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    ! -- return mesh object
+    if (present(rc)) rc = ESMF_SUCCESS
+    NamespaceGetMesh = mesh
+    
+  end function NamespaceGetMesh
+
+!------------------------------------------------------------------------------
+
+  subroutine NamespaceGetLocal(name, geomtype, grid, mesh, rc)
+    character(len=*),          intent(in) :: name
+    type(ESMF_GeomType_Flag), intent(out) :: geomtype
+    type(ESMF_Grid),          intent(out) :: grid
+    type(ESMF_Mesh),          intent(out) :: mesh
+    integer, optional, intent(out) :: rc
+
+    ! -- local variables
+    integer                     :: localrc
+    type(compType),     pointer :: p
+    type(stateType),    pointer :: s
+
+    ! -- begin
+    localrc = ESMF_RC_NOT_FOUND
+    if (present(rc)) rc = ESMF_RC_NOT_FOUND
+
+    geomtype = ESMF_GEOMTYPE_UNINIT
+
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == trim(name)) then
+        s => p % stateList
+        do while (associated(s))
+          if (ESMF_GridIsCreated(s % localGrid)) then
+            grid = s % localGrid
+            geomtype = ESMF_GEOMTYPE_GRID
+            localrc  = ESMF_SUCCESS
+          else if (ESMF_MeshIsCreated(s % localMesh)) then
+            mesh = s % localMesh
+            geomtype = ESMF_GEOMTYPE_MESH
+            localrc  = ESMF_SUCCESS
+          end if
+          s => s % next
+        end do
+      end if
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+    if (localrc == ESMF_RC_NOT_FOUND) then
+      call ESMF_LogSetError(localrc, &
+        msg="No Grid or Mesh object found in namespace "//trim(name), &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+  end subroutine NamespaceGetLocal
+
+!------------------------------------------------------------------------------
+
+  function GridCreateFromGrid(grid, minIndex, maxIndex, rc)
+    ! -- input variables
+    type(ESMF_Grid),   intent(in) :: grid
+    integer, optional, intent(in) :: minIndex
+    integer,           intent(in) :: maxIndex
+
+    ! -- output variables
+    type(ESMF_Grid) :: GridCreateFromGrid
+    integer, optional, intent(out) :: rc
+
+    ! -- local variables
+    integer :: localrc
+    integer :: connectionCount, deCount, dimCount, itemCount, tileCount
+    integer :: ldimCount, localDe, localDeCount, minIndx
+    integer :: item
+    integer :: tileIndexA, tileIndexB
+    integer, dimension(:),       pointer :: positionVector,    orientationVector
+    integer, dimension(:),       pointer :: newPositionVector, newOrientationVector
+    integer, dimension(:),   allocatable :: coordDimCount,    distgridToGridMap
+    integer, dimension(:),   allocatable :: newcoordDimCount, newdistgridToGridMap
+    integer, dimension(:,:), allocatable :: coordDimMap,    minIndexPTile,    maxIndexPTile
+    integer, dimension(:,:), allocatable :: newcoordDimMap, newminIndexPTile, newmaxIndexPTile
+    real(ESMF_KIND_R8), dimension(:),     pointer :: fptrIn1d, fptrOut1d
+    real(ESMF_KIND_R8), dimension(:,:),   pointer :: fptrIn2d, fptrOut2d
+    type(ESMF_DistGridConnection), dimension(:), allocatable :: connectionList, newconnectionList
+    type(ESMF_DistGrid)         :: distgrid, newdistgrid
+    type(ESMF_Grid)             :: newgrid
+    type(ESMF_GeomType_Flag)    :: geomtype
+    type(ESMF_Index_Flag)       :: indexflag
+    type(ESMF_CoordSys_Flag)    :: coordSys
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    ! -- check additional dimension bounds
+    minIndx = 1
+    if (present(minIndex)) then
+      minIndx = minIndex 
+    end if
+
+    if (maxIndex <= minIndx) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="maxIndex must be > minIndex", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- get grid parameters and associated DistGrid object
+    call ESMF_GridGet(grid, distgrid=distgrid, &
+      dimCount=dimCount, coordSys=coordSys, indexflag=indexflag, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    if (dimCount /= 2) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Grid object in field MUST have 2 dimensions", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- get 2D distribution information from Grid's DistGrid object
+    allocate(coordDimCount(dimCount),  &
+      distgridToGridMap(dimCount),     &
+      coordDimMap(dimCount,dimCount), &
+      stat=localrc)
+    if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    call ESMF_GridGet(grid, coordDimCount=coordDimCount, &
+      distgridToGridMap=distgridToGridMap, &
+      coordDimMap=coordDimMap, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- increment dimension count by one to build local 3D Grid
+    ldimCount = dimCount + 1
+
+    ! -- create mapping arrays for 3D Grid by extending original ones from 2D Grid
+    allocate(newcoordDimCount(ldimCount),  &
+      newdistgridToGridMap(ldimCount),     &
+      newcoordDimMap(ldimCount,ldimCount), &
+      stat=localrc)
+    if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    newcoordDimCount(1:dimCount)    = coordDimCount
+    newcoordDimCount(ldimCount)     = 3
+
+    newdistgridToGridMap(1:dimCount) = distgridToGridMap
+    newdistgridToGridMap(ldimCount)  = 3
+
+    newcoordDimMap(1:dimCount,1:dimCount) = coordDimMap
+    newcoordDimMap(:, ldimCount) = 1
+    newcoordDimMap(ldimCount, :) = (/ 1, 2, 3 /)
+
+    deallocate(coordDimCount, distgridToGridMap, coordDimMap, stat=localrc)
+    if (ESMF_LogFoundDeallocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- in a similar fashion, extend index/tile arrays and connection settings
+    ! -- for DistGrid object in new 3D Grid
+
+    ! -- get original DistGrid information
+    call ESMF_DistGridGet(distgrid, &
+      tileCount=tileCount, connectionCount=connectionCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    allocate(minIndexPTile(dimCount, tileCount), &
+             maxIndexPTile(dimCount, tileCount), &
+             connectionList(connectionCount),    &
+             stat=localrc)
+    if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- get original index arrays and connection list
+    call ESMF_DistGridGet(distgrid, minIndexPTile=minIndexPTile, &
+      maxIndexPTile=maxIndexPTile, connectionList=connectionList, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- create new index arrays
+    allocate(newminIndexPTile(ldimCount, tileCount), &
+             newmaxIndexPTile(ldimCount, tileCount), &
+             stat=localrc)
+    if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    newminIndexPTile(1:dimCount,:) = minIndexPTile
+    newmaxIndexPTile(1:dimCount,:) = maxIndexPTile
+    newminIndexPTile(ldimCount, :) = minIndx
+    newmaxIndexPTile(ldimCount, :) = maxIndex
+
+    deallocate(minIndexPTile, maxIndexPTile, stat=localrc)
+    if (ESMF_LogFoundDeallocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- extend connection list for new Grid
+    allocate(newConnectionList(connectionCount), &
+             newPositionVector(ldimCount), newOrientationVector(ldimCount), &
+             stat=localrc)
+    if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    do item = 1, connectionCount
+      ! -- WARNING: this interface needs to be finalized
+      call ESMF_DistGridConnectionGet(connectionList(item), &
+        tileIndexA=tileIndexA, tileIndexB=tileIndexB, &
+        positionVector=positionVector, orientationVector=orientationVector, &
+        rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+
+      newPositionVector(1:dimCount) = positionVector
+      newPositionVector( ldimCount) = 0
+      newOrientationVector(1:dimCount) = orientationVector
+      newOrientationVector( ldimCount) = 3
+
+      call ESMF_DistGridConnectionSet(newConnectionList(item), &
+        tileIndexA=tileIndexA, tileIndexB=tileIndexB, &
+        positionVector=newPositionVector, orientationVector=newOrientationVector, &
+        rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+    end do
+
+    deallocate(newPositionVector, newOrientationVector, connectionList, stat=localrc)
+    if (ESMF_LogFoundDeallocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- create 3D DistGrid object
+    newdistgrid = ESMF_DistGridCreate(minIndexPTile=newminIndexPTile, &
+      maxIndexPTile=newmaxIndexPTile, connectionList=newConnectionList, &
+      rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    deallocate(newminIndexPTile, newmaxIndexPTile, newconnectionList, stat=localrc)
+    if (ESMF_LogFoundDeallocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- create 3D Grid object
+    newgrid = ESMF_GridCreate(newdistgrid, coordDimCount=newcoordDimCount, &
+      coordDimMap=newcoordDimMap, coordSys=coordSys, indexflag=indexflag, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    deallocate(newcoordDimMap, stat=localrc)
+    if (ESMF_LogFoundDeallocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- get localDeCount
+    call ESMF_GridGet(newgrid, localDeCount=localDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- add coordinates to 3D Grid
+    call ESMF_GridAddCoord(newgrid, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    write(6,'("newcoord: BEGIN")')
+    flush 6
+    ! -- load 2D coordinates
+    do item = 1, 2
+      select case (newcoordDimCount(item))
+        case (1)
+          do localDe = 0, localDeCount - 1
+            call ESMF_GridGetCoord(grid, coordDim=item, localDE=localDe, &
+              farrayPtr=fptrOut1d, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)) return
+            call ESMF_GridGetCoord(newgrid, coordDim=item, localDE=localDe, &
+              farrayPtr=fptrIn1d, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)) return
+            fptrIn1d = fptrOut1d
+            write(6,'("newcoord: ",i0,2x,"DE: ",i0," min/max: ",2g16.6)') item, localDe, minval(fptrIn1d), maxval(fptrIn1d)
+            flush 6
+          end do
+        case (2)
+          do localDe = 0, localDeCount - 1
+            call ESMF_GridGetCoord(grid, coordDim=item, localDE=localDe, &
+              farrayPtr=fptrOut2d, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)) return
+            call ESMF_GridGetCoord(newgrid, coordDim=item, localDE=localDe, &
+              farrayPtr=fptrIn2d, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)) return
+            fptrIn2d = fptrOut2d
+            write(6,'("newcoord: ",i0,2x,"DE: ",i0," min/max: ",2g16.6)') item, localDe, minval(fptrIn2d), maxval(fptrIn2d)
+            flush 6
+          end do
+        case default
+            write(6,'("newcoord: ",i0,2x,"NO COORDINATE SET")') item
+            flush 6
+      end select
+    end do
+    write(6,'("newcoord: END")')
+    flush 6
+
+    deallocate(newcoordDimCount, stat=localrc)
+    if (ESMF_LogFoundDeallocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    GridCreateFromGrid = newgrid
+
+  end function GridCreateFromGrid
+
+!------------------------------------------------------------------------------
+
+  function GridAddNewCoord(grid, staggerloc, coord, scale, offset, rc)
+    ! -- input variables
+    type(ESMF_Grid),                    intent(in) :: grid
+    type(ESMF_StaggerLoc),    optional, intent(in) :: staggerloc
+    real(ESMF_KIND_R8),                 intent(in) :: coord(:)
+    real(ESMF_KIND_R8),       optional, intent(in) :: scale
+    real(ESMF_KIND_R8),       optional, intent(in) :: offset
+
+    ! -- output variables
+    integer, optional, intent(out) :: rc
+    type(ESMF_Grid) :: GridAddNewCoord
+
+    ! -- local variables
+    logical :: isPresent
+    integer :: localrc
+    integer :: localDe, localDeCount
+    integer :: k, lsize
+    integer :: minIndx, maxIndx
+    integer, dimension(3)       :: lbnd, ubnd
+    real(ESMF_KIND_R8)          :: scale_factor, add_offset
+    real(ESMF_KIND_R8), pointer :: fptrIn3d(:,:,:)
+    type(ESMF_Grid)             :: newgrid
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    newgrid = GridCreateFromGrid(grid, maxIndex=size(coord), rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    isPresent = .false.
+    call ESMF_GridGetCoord(newgrid, staggerloc=staggerloc, &
+      isPresent=isPresent, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    if (.not.isPresent) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="This stagger location was not included in the new grid", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- get localDeCount
+    call ESMF_GridGet(newgrid, localDeCount=localDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- load vertical coordinate
+    scale_factor = 1._ESMF_KIND_R8
+    add_offset   = 0._ESMF_KIND_R8
+    if (present(scale)) scale_factor = scale
+    if (present(offset)) add_offset  = offset
+
+    do localDe = 0, localDeCount - 1
+
+      ! -- get coordinate pointer from new grid
+      call ESMF_GridGetCoord(newgrid, coordDim=3, localDE=localDe, &
+        staggerloc=staggerloc, &
+        computationalLBound=lbnd, computationalUBound=ubnd, &
+        farrayPtr=fptrIn3d, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+
+      ! -- check allocated memory size
+      lsize = ubnd(3)-lbnd(3)+1
+      if (lsize /= size(coord)) then
+        call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+          msg="size of coord array does not match internal coordinate size",&
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if
+
+      do k = 1, lsize
+        fptrIn3d(lbnd(1):ubnd(1),lbnd(2):ubnd(2),k+lbnd(3)-1) = scale_factor * coord(k) + add_offset
+      end do
+
+    end do
+
+    GridAddNewCoord = newgrid
+
+  end function GridAddNewCoord
+
+!------------------------------------------------------------------------------
+
+  function GridCreateFromField(field, scale, offset, rc)
+    ! -- input variables
+    type(ESMF_Field), intent(in) :: field
+    real(ESMF_KIND_R8), optional, intent(in) :: scale, offset
+
+    ! -- output variables
+    type(ESMF_Grid) :: GridCreateFromField
+    integer, optional, intent(out) :: rc
+
+    ! -- local variables
+    integer :: localrc
+    integer :: localDe, localDeCount
+    integer :: item, itemCount
+    integer :: ungriddedBound, vSize
+    real(ESMF_KIND_R8)          :: scale_factor, add_offset
+    real(ESMF_KIND_R8), dimension(:,:,:), pointer :: fptrIn3d, fptrOut3d
+    type(ESMF_Grid)             :: grid, newgrid
+    type(ESMF_FieldStatus_Flag) :: fieldStatus
+    type(ESMF_GeomType_Flag)    :: geomtype
+
+    character(len=*), dimension(2), parameter :: &
+      AttributeList = (/ "UngriddedLBound", "UngriddedUBound" /)
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    ! -- check if field is completed
+    call ESMF_FieldGet(field, status=fieldStatus, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    if (fieldStatus /= ESMF_FIELDSTATUS_COMPLETE) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Field has not been completely created.", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field contains valid grid object
+    call ESMF_FieldGet(field, geomtype=geomtype, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    if (geomtype /= ESMF_GEOMTYPE_GRID) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="No Grid object found in field ", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field has ungridded dimension
+    vSize = 0
+    do item = 1, 2
+      call ESMF_AttributeGet(field, name=trim(AttributeList(item)), &
+        convention="NUOPC", purpose="Instance", &
+        itemCount=itemCount, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return  ! bail out
+      if (itemCount == 1) then
+        call ESMF_AttributeGet(field, name=trim(AttributeList(item)), &
+          convention="NUOPC", purpose="Instance", &
+          value=ungriddedBound, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)) return  ! bail out
+        vSize = ungriddedBound - vSize
+      else
+        call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+          msg="Field must have ONE ungridded dimension!", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+          return  ! bail out
+       end if
+     end do
+     vSize = vSize + 1
+
+    ! -- create 3D grid from field's 2D grid and vertical dimension
+    ! -- get original 2D grid from field
+    call ESMF_FieldGet(field, grid=grid, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    ! -- add vertical dimension
+    newgrid = GridCreateFromGrid(grid, minIndex=1, maxIndex=vSize, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    ! -- get new grid's localDeCount
+    call ESMF_GridGet(newgrid, localDeCount=localDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    ! -- load vertical coordinate
+    scale_factor = 1._ESMF_KIND_R8
+    add_offset   = 0._ESMF_KIND_R8
+    if (present(scale)) scale_factor = scale
+    if (present(offset)) add_offset  = offset
+
+    do localDe = 0, localDeCount - 1
+
+      call ESMF_FieldGet(field, localDE=localDe, farrayPtr=fptrOut3d, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+
+      call ESMF_GridGetCoord(newgrid, coordDim=3, localDE=localDe, &
+        staggerloc=ESMF_STAGGERLOC_CENTER, &
+        farrayPtr=fptrIn3d, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+
+      fptrIn3d = scale_factor * fptrOut3d + add_offset
+
+    end do
+
+    GridCreateFromField = newgrid
+
+  end function GridCreateFromField
+
+!------------------------------------------------------------------------------
+
+  subroutine MeshGetBounds(mesh, dim, bounds, rc)
+    type(ESMF_Mesh), intent(in) :: mesh
+    integer,         intent(in) :: dim
+    real(ESMF_KIND_R8), intent(out) :: bounds(2)
+    integer, optional,  intent(out) :: rc
+
+    ! -- local variables
+    integer :: localrc, numOwnedNodes, spatialDim
+    real(ESMF_KIND_R8), dimension(:), allocatable, target :: ownedNodeCoords
+    real(ESMF_KIND_R8), dimension(:), pointer :: p
+    real(ESMF_KIND_R8), dimension(1) :: sendData, recvData
+    type(ESMF_VM) :: vm
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    bounds(2) = huge(0._ESMF_KIND_R8)
+    bounds(1) = -bounds(2)
+
+    call ESMF_MeshGet(mesh, spatialDim=spatialDim, &
+      numOwnedNodes=numOwnedNodes, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    if (dim > spatialDim) then
+      call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
+        msg="dim argument is higher than Mesh spatial dimension", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    allocate(ownedNodeCoords(spatialDim*numOwnedNodes), stat=localrc)
+    if (ESMF_LogFoundAllocError(statusToCheck=localrc, &
+      msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) &
+      return
+
+    call ESMF_MeshGet(mesh, ownedNodeCoords=ownedNodeCoords, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    call ESMF_VMGetCurrent(vm, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    p => ownedNodeCoords(dim::spatialDim)
+    sendData(1) = minval(p)
+    recvData    = 0._ESMF_KIND_R8
+
+    call ESMF_VMAllReduce(vm, sendData, recvData, 1, ESMF_REDUCE_MIN, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    bounds(1) = recvData(1)
+
+    sendData(1) = maxval(p)
+    recvData    = 0._ESMF_KIND_R8
+
+    call ESMF_VMAllReduce(vm, sendData, recvData, 1, ESMF_REDUCE_MAX, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    bounds(2) = recvData(1)
+    
+  end subroutine MeshGetBounds
+
+  function MeshAddNewCoord(mesh, coord, scale, offset, rc)
+    ! -- input variables
+    type(ESMF_Mesh),                    intent(in) :: mesh
+    real(ESMF_KIND_R8),                 intent(in) :: coord(:)
+    real(ESMF_KIND_R8),       optional, intent(in) :: scale
+    real(ESMF_KIND_R8),       optional, intent(in) :: offset
+
+    ! -- output variables
+    integer, optional, intent(out) :: rc
+    type(ESMF_Mesh) :: MeshAddNewCoord
+
+    ! -- local variables
+    integer :: localrc
+    integer :: connectionCount, deCount, dimCount, localDe, localDeCount
+    integer :: numOwnedNodes
+    integer :: i, de, dim
+    integer, dimension(:),   allocatable :: indexList, localDeToDeMap
+    integer, dimension(:,:), allocatable :: indexCountPDe, dimExtent
+    real(ESMF_KIND_R8), dimension(:), allocatable :: ownedNodeCoords
+    type(ESMF_DELayout) :: delayout
+    type(ESMF_DistGrid) :: distgrid
+    type(ESMF_DistGridConnection), dimension(:), allocatable :: connectionList
+    type(ESMF_CoordSys_Flag) :: coordSys
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    call ESMF_MeshGet(mesh, nodalDistGrid=distgrid, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    call ESMF_DistGridGet(distgrid, connectionCount=connectionCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    write(6,'(" -- MeshAddNewCoord: connectionCount = ",i0)') connectionCount
+
+    allocate(connectionList(connectionCount))
+    call ESMF_DistGridGet(distgrid, connectionList=connectionList, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    do i = 1, connectionCount
+      call ESMF_DistGridConnectionPrint(connectionList(i), rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+    end do
+
+    deallocate(connectionList)
+
+    call ESMF_DistGridGet(distgrid, dimCount=dimCount, deCount=deCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    write(6,'(" -- MeshAddNewCoord: dimCount = ",i0,", deCount = ",i0)') dimCount, deCount
+
+    allocate(indexCountPDe(dimCount, deCount))
+    call ESMF_DistGridGet(distgrid, indexCountPDe=indexCountPDe, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    write(6,'(" -- MeshAddNewCoord: indexCountPDe = ",10i6)') indexCountPDe
+
+    ! --------- get index list from DistGrid object ----------
+
+    allocate(dimExtent(dimCount, 0:deCount-1))
+    call ESMF_DistGridGet(distgrid, delayout=delayout, &
+      indexCountPDe=dimExtent, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    call ESMF_DELayoutGet(delayout, localDeCount=localDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    allocate(localDeToDeMap(0:localDeCount-1))
+    call ESMF_DELayoutGet(delayout, localDeToDeMap=localDeToDeMap, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    do localDe=0, localDeCount-1
+      de = localDeToDeMap(localDe)
+      do dim=1, dimCount
+        allocate(indexList(dimExtent(dim, de))) ! allocate list 
+                                                     ! to hold indices
+        call ESMF_DistGridGet(distgrid, localDe=localDe, dim=dim, &
+          indexList=indexList, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)) return
+
+        write(6,'(" -- MeshAddNewCoord: localDE: ",i0,", DE: ",i0," dim = ",i0," indexList first/last = ",2i8)') &
+          localDe, de, dim, indexList(1), indexList(size(indexList))
+        deallocate(indexList)
+      enddo
+    enddo
+    deallocate(localDeToDeMap)
+    deallocate(dimExtent)
+
+    ! --------- get index list from DistGrid object (done) ----------
+#if 0
+    allocate(indexList(indexCountPDe(1,1)))
+    call ESMF_DistGridGet(distgrid, 0, 1, indexList, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+    write(6,'(" -- MeshAddNewCoord: indexList first/last = ",2i8)') &
+      indexList(1), indexList(size(indexList))
+
+    deallocate(indexCountPDe)
+#endif
+    deallocate(indexList)
+
+    call ESMF_MeshGet(mesh, numOwnedNodes=numOwnedNodes, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+    write(6,'(" -- MeshAddNewCoord: numOwnedNodes = ",i0)') numOwnedNodes
+
+    allocate(ownedNodeCoords(numOwnedNodes))
+    call ESMF_MeshGet(mesh, ownedNodeCoords=ownedNodeCoords, &
+      coordSys=coordSys, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+    write(6,'(" -- MeshAddNewCoord: ownedNodeCoords first/last = ",4g16.6)') &
+      ownedNodeCoords(1), ownedNodeCoords(2), &
+      ownedNodeCoords(numOwnedNodes-1), ownedNodeCoords(numOwnedNodes)
+
+#if 0
+    do k = 1, numOwnedNodes
+      
+    end do
+
+    localMesh = ESMF_MeshCreate(parametricDim=3, spatialDim=3, coordSys=coordSys, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return
+
+#endif
+
+    MeshAddNewCoord = mesh
+
+  end function MeshAddNewCoord
+
+!------------------------------------------------------------------------------
+
+  subroutine NamespaceSetLocalGrid(name, grid, rc)
+    character(len=*), intent(in) :: name
+    type(ESMF_Grid)              :: grid
+    integer,         intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+    logical                  :: isGridCreated
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    isGridCreated = ESMF_GridIsCreated(grid, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    if (isGridCreated) then
+      p => compList
+      nullify(s)
+      do while (associated(p))
+        if (trim(p % name) == name) then
+          s => p % stateList
+          do while (associated(s))
+            s % localGrid  = grid
+            s % localField = ESMF_FieldCreate(grid, ESMF_TYPEKIND_R8, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            s => s % next
+          end do
+        end if
+        p => p % next
+      end do
+    else
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Invalid Grid object (not yet created)", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+  end subroutine NamespaceSetLocalGrid
+
+  subroutine NamespaceSetLocalGridFromField(name, state, fieldName, scale, offset, rc)
+    character(len=*), intent(in) :: name
+    type(ESMF_State)             :: state
+    character(len=*), intent(in) :: fieldName
+    real(ESMF_KIND_R8), optional, intent(in) :: scale, offset
+    integer,         intent(out) :: rc
+
+    ! -- local variables
+    type(ESMF_Field)            :: field
+    type(ESMF_Grid)             :: localGrid, grid
+    type(ESMF_Mesh)             :: localMesh
+    type(ESMF_GeomType_Flag)    :: geomtype
+    type(ESMF_FieldStatus_Flag) :: fieldStatus
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    field = NamespaceGetField(name, state, fieldName, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! -- check if field is completed
+    call ESMF_FieldGet(field, status=fieldStatus, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    if (fieldStatus /= ESMF_FIELDSTATUS_COMPLETE) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Field has not been completely created.", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- check if field contains valid grid object
+    call ESMF_FieldGet(field, geomtype=geomtype, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    if (geomtype /= ESMF_GEOMTYPE_GRID) then
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="No Grid object found in field "// fieldName, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    grid = GridCreateFromField(field, scale=scale, offset=offset, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+     
+    call NamespaceSetLocalGrid(name, grid, rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+#if 0
+    ! -- write 3D Grid object as Mesh (VTK file) for debugging purposes
+    localMesh = ESMF_GridToMesh(grid, staggerloc=ESMF_STAGGERLOC_CENTER, &
+      isSphere=1, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call ESMF_MeshWrite(localMesh, 'localmesh', rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+#endif
+
+  end subroutine NamespaceSetLocalGridFromField
+
+  subroutine NamespaceSetLocalMesh(name, mesh, rc)
+    character(len=*), intent(in) :: name
+    type(ESMF_Mesh)              :: mesh
+    integer,         intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+    logical                  :: isMeshCreated
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    isMeshCreated = ESMF_MeshIsCreated(mesh, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    if (isMeshCreated) then
+      p => compList
+      nullify(s)
+      do while (associated(p))
+        if (trim(p % name) == name) then
+          s => p % stateList
+          do while (associated(s))
+            s % localMesh  = mesh
+            s % localField = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            s => s % next
+          end do
+        end if
+        p => p % next
+      end do
+    else
+      call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
+        msg="Invalid Mesh object (not yet created)", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+  end subroutine NamespaceSetLocalMesh
+
+  subroutine GetDataFromField(name, state, fieldName, farrayPtr, localDe, rc)
+    ! -- input variables
+    character(len=*), intent(in) :: name
+    type(ESMF_State)             :: state
+    character(len=*), intent(in) :: fieldName
+    real(ESMF_KIND_R8), dimension(:,:,:), pointer :: farrayPtr
+    integer,         optional, intent(in)  :: localDe
+    integer,         optional, intent(out) :: rc
+    ! -- output variables
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+    type(ESMF_Field)         :: field
+    integer                  :: item, de
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    de = 0
+    if (present(localDe)) de = localDe
+
+    nullify(farrayPtr)
+       
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == name) then
+        s => p % stateList
+        do while (associated(s))
+          if (s % parent == state) then
+            if (associated(s % fieldNames)) then
+              do item = 1, size(s % fieldNames) 
+                if (trim(s % fieldNames(item)) == fieldName) then
+                  call ESMF_StateGet(s % self, field=field, itemName=fieldName, rc=rc)
+                  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__)) &
+                    return  ! bail out
+                  call ESMF_FieldGet(field, localDe=de, farrayPtr=farrayPtr, rc=rc)
+                  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__)) &
+                    return  ! bail out
+                  return  ! exit function
+                end if
+              end do 
+            end if
+          end if
+          s => s % next
+        end do
+      end if
+      p => p % next
+    end do
+
+    nullify(p, s)
+
+  end subroutine GetDataFromField
+
+  subroutine NamespaceSetRemoteLevels(name, array, rc)
+    character(len=*), intent(in) :: name
+    type(ESMF_Array), intent(in) :: array
+    integer,         intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p
+    type(stateType), pointer :: s
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+  
+    nullify(s)
+    p => compList
+    do while (associated(p))
+      if (trim(p % name) == name) then
+        s => p % stateList
+        do while (associated(s))
+          s % remoteLevels = array
+          s => s % next
+        end do
+      end if
+      p => p % next
+    end do
+
+    nullify(p, s)
+     
+  end subroutine NamespaceSetRemoteLevels
+
+  subroutine NamespaceSetRemoteLevelsFromField(name, state, fieldName, scale, offset, rc)
+    character(len=*), intent(in) :: name
+    type(ESMF_State)             :: state
+    character(len=*), intent(in) :: fieldName
+    real(ESMF_KIND_R8), optional, intent(in) :: scale, offset
+    integer,         intent(out) :: rc
+
+    ! -- local variables
+    logical            :: update
+    integer            :: localDe, localDeCount, rank
+    real(ESMF_KIND_R8) :: scale_factor, add_offset
+    real(ESMF_KIND_R8), dimension(:),     pointer :: fptr1d
+    real(ESMF_KIND_R8), dimension(:,:),   pointer :: fptr2d
+    real(ESMF_KIND_R8), dimension(:,:,:), pointer :: fptr3d
+    type(ESMF_Field)   :: field
+    type(ESMF_Array)   :: array, localArray
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    field = NamespaceGetField(name, state, fieldName, rc)
+
+    call ESMF_FieldGet(field, array=array, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    update = .false.
+    scale_factor = 1._ESMF_KIND_R8
+    add_offset   = 0._ESMF_KIND_R8
+    if (present(scale)) then
+      scale_factor = scale
+      update = .true.
+    end if
+
+    if (present(offset)) then
+      add_offset = offset
+      update = .true.
+    end if
+
+    if (update) then
+      localArray = ESMF_ArrayCreate(array, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      call ESMF_ArrayGet(localArray, rank=rank, localDeCount=localDeCount, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      do localDe = 0, localDeCount - 1
+        select case (rank)
+          case(1)
+            call ESMF_ArrayGet(localArray, localDe=localDe, farrayPtr=fptr1d, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            fptr1d = scale_factor * fptr1d + add_offset
+          case(2)
+            call ESMF_ArrayGet(localArray, localDe=localDe, farrayPtr=fptr2d, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            fptr2d = scale_factor * fptr2d + add_offset
+          case(3)
+            call ESMF_ArrayGet(localArray, localDe=localDe, farrayPtr=fptr3d, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+            fptr3d = scale_factor * fptr3d + add_offset
+          case default
+            call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+              msg="Array rank can only be 1, 2, or 3", &
+              line=__LINE__, &
+              file=__FILE__, &
+              rcToReturn=rc)
+            return ! bail out
+        end select
+      end do
+    else
+      localArray = array
+    end if
+
+    call NamespaceSetRemoteLevels(name, localArray, rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+       
+  end subroutine NamespaceSetRemoteLevelsFromField
+
+  ! -- Namespace: Create/Get/Set methods: end definition --
+
+  ! -- Namespace: Field Retrieve/Store/Interpolate/Release methods: begin definition --
+
+  subroutine VerticalInterpolate1D(srcCoord, srcfarray, dstCoord, dstfarray, auxfarray, options, rc)
+    real(ESMF_KIND_R8), dimension(:,:),  intent(in) :: srcfarray, srcCoord, dstCoord
+    real(ESMF_KIND_R8), dimension(:,:), intent(out) :: dstfarray
+    real(ESMF_KIND_R8), dimension(:,:), optional, intent(in) :: auxfarray
+    character(len=*), optional, intent(in) :: options
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    logical :: isFlag
+    integer :: i, j, k, localrc
+    integer :: lbnd, ubnd
+    real(ESMF_KIND_R8) :: auxNorm, rt
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    ! -- check if src and dst arrays have same horizontal decompositions
+    isFlag = .false.
+    lbnd = lbound(srcfarray, dim=1)
+    isFlag = (lbound(dstfarray, dim=1) /= lbnd) 
+    if (.not.isFlag) then
+      ubnd = ubound(srcfarray, dim=1)
+      isFlag = (ubound(dstfarray, dim=1) /= ubnd)
+    end if
+    if (isFlag) then
+      call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+        msg="src and dst arrays defined on different 1D regions (mismatched lower/upper bounds)", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- pick interpolation method
+    auxNorm = 0._ESMF_KIND_R8
+    if (present(options)) then
+      read(options, *, iostat=localrc) auxNorm
+      if (localrc /= 0) auxNorm = 0._ESMF_KIND_R8
+    end if
+      
+    if (auxNorm > 0._ESMF_KIND_R8) then
+      if (present(auxfarray)) then
+        ! -- log interpolation + extrapolation w/ hypsometric equation
+        do i = lbnd, ubnd
+          rt = auxfarray(i,ubound(auxfarray, dim=2)) / auxNorm
+          call LogInterpolate(srcCoord(i,:), srcfarray(i,:), &
+                              dstCoord(i,:), dstfarray(i,:), &
+                              rt=rt, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+        end do
+      else
+        ! -- log interpolation, no extrapolation
+        do i = lbnd, ubnd
+          call LogInterpolate(srcCoord(i,:), srcfarray(i,:), &
+                              dstCoord(i,:), dstfarray(i,:), &
+                              rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+        end do
+      end if
+    else
+        ! -- linear interpolation, extrapolate with constant value
+      do i = lbnd, ubnd
+        call PolyInterpolate(srcCoord(i,:), srcfarray(i,:), &
+                             dstCoord(i,:), dstfarray(i,:), 1, rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      end do
+    end if
+
+  end subroutine VerticalInterpolate1D
+
+! subroutine Interpolate(srcCoord, srcfarray, dstCoord, dstfarray, auxfarray, options, rc)
+  subroutine VerticalInterpolate2D(srcCoord, srcfarray, dstCoord, dstfarray, auxfarray, options, rc)
+    real(ESMF_KIND_R8), dimension(:,:,:),  intent(in) :: srcfarray, srcCoord, dstCoord
+    real(ESMF_KIND_R8), dimension(:,:,:), intent(out) :: dstfarray
+    real(ESMF_KIND_R8), dimension(:,:,:), optional, intent(in) :: auxfarray
+    character(len=*), optional, intent(in) :: options
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    logical :: isFlag
+    integer :: i, j, k, localrc
+    integer, dimension(2) :: lbnd, ubnd
+    real(ESMF_KIND_R8) :: auxNorm, rt
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    ! -- check if src and dst arrays have same horizontal decompositions
+    isFlag = .false.
+    do i = 1, 2
+      lbnd(i) = lbound(srcfarray, dim=i)
+      isFlag = (lbound(dstfarray, dim=i) /= lbnd(i)) 
+      if (isFlag) exit
+      ubnd(i) = ubound(srcfarray, dim=i)
+      isFlag = (ubound(dstfarray, dim=i) /= ubnd(i))
+      if (isFlag) exit
+    end do
+    if (isFlag) then
+      call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+        msg="src and dst arrays defined on different 2D regions (mismatched lower/upper bounds)", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    ! -- pick interpolation method
+    auxNorm = 0._ESMF_KIND_R8
+    if (present(options)) then
+      read(options, *, iostat=localrc) auxNorm
+      if (localrc /= 0) auxNorm = 0._ESMF_KIND_R8
+    end if
+      
+    if (auxNorm > 0._ESMF_KIND_R8) then
+      if (present(auxfarray)) then
+        ! -- log interpolation + extrapolation w/ hypsometric equation
+        do j = lbnd(2), ubnd(2)
+          do i = lbnd(1), ubnd(1)
+            rt = auxfarray(i,j,ubound(auxfarray, dim=3)) / auxNorm
+            call LogInterpolate(srcCoord(i,j,:), srcfarray(i,j,:), &
+                                dstCoord(i,j,:), dstfarray(i,j,:), &
+                                rt=rt, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+          end do
+        end do
+      else
+        ! -- log interpolation, no extrapolation
+        do j = lbnd(2), ubnd(2)
+          do i = lbnd(1), ubnd(1)
+            call LogInterpolate(srcCoord(i,j,:), srcfarray(i,j,:), &
+                                dstCoord(i,j,:), dstfarray(i,j,:), &
+                                rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail out
+          end do
+        end do
+      end if
+    else
+        ! -- linear interpolation, extrapolate with constant value
+      do j = lbnd(2), ubnd(2)
+        do i = lbnd(1), ubnd(1)
+          call PolyInterpolate(srcCoord(i,j,:), srcfarray(i,j,:), &
+                               dstCoord(i,j,:), dstfarray(i,j,:), 1, rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+        end do
+      end do
+    end if
+
+  end subroutine VerticalInterpolate2D
+
+  subroutine PolyInterpolate(xs, ys, xd, yd, m, rc)
+    real(ESMF_KIND_R8), dimension(:), intent(in)  :: xs, ys, xd
+    real(ESMF_KIND_R8), dimension(:), intent(out) :: yd
+    integer, intent(in)  :: m
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    integer :: i, j, k, n, np
+    real(ESMF_KIND_R8) :: x, y, dy
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    n = m + 1
+    np = size(xs)
+    do i = 1, size(xd)
+      x = xd(i)
+      y = 0._ESMF_KIND_R8
+      call locate(xs, np, x, j)
+      if (j == np) then
+        y = ys(np)
+      else if (j > 0) then
+        k = min(max(j-(n-1)/2,1), np+1-n)
+        call polint(xs(k:), ys(k:), n, x, y, dy, rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg="Error in polint", &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      end if
+      yd(i) = y
+    end do
+    
+  end subroutine PolyInterpolate
+
+  subroutine LogInterpolate(xs, ys, xd, yd, rt, rc)
+    ! -- note: both xs and xd are assumed to be "normalized" heights
+    ! --       x = 1 + z / earthRadius
+    ! -- if absolute heights (km) are used, please set earthRadius = 1
+    real(ESMF_KIND_R8), dimension(:), intent(in)  :: xs, ys, xd
+    real(ESMF_KIND_R8), dimension(:), intent(out) :: yd
+    real(ESMF_KIND_R8), optional, intent(in) :: rt  ! reduced T = T / mass
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    integer, parameter :: n = 2  ! linear interpolation (2 points)
+    integer :: i, itop, j, k, np, nd
+    real(ESMF_KIND_R8) :: fact, x, x1, y, y1, dy, ylog(n)
+
+    real(ESMF_KIND_R8), parameter :: log_min = 1.e-10_ESMF_KIND_R8
+    real(ESMF_KIND_R8), parameter :: g0 = 9.80665_ESMF_KIND_R8
+    real(ESMF_KIND_R8), parameter :: Rgas = 8.3141_ESMF_KIND_R8
+    real(ESMF_KIND_R8), parameter :: earthRadius = 6371.2_ESMF_KIND_R8
+    real(ESMF_KIND_R8), parameter :: const = 2 * g0 * earthRadius / Rgas
+ 
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    np = size(xs)
+    nd = size(xd)
+    yd = 0._ESMF_KIND_R8
+
+    ! -- interpolate
+    do i = 1, nd
+      x = xd(i)
+      y = 0._ESMF_KIND_R8
+      call locate(xs, np, x, j)
+      if (j == np) then
+        itop = i
+        exit
+      else if (j > 0) then
+        k = min(max(j-(n-1)/2,1), np+1-n)
+        ylog = log(max(ys(k:k+n-1), log_min))
+        call polint(xs(k:), ylog, n, x, y, dy, rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg="Error in polint", &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      end if
+      yd(i) = exp(y)
+    end do
+
+    ! -- extrapolatw with hypsometric equation
+    if (present(rt)) then
+      if (rt <= 0._ESMF_KIND_R8) then
+        call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
+          msg="Optional rt argument (T/m) must be > 0", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if 
+      x1 = xs(np) 
+      y1 = ys(np) 
+      fact = const / rt
+      do i = itop, nd
+        y = fact * (x1-xd(i)) / (x1*x1+xd(i)*xd(i))
+        yd(i) = y1 * exp(y)
+        x1 = xd(i)
+        y1 = yd(i)
+      end do
+    end if
+
+  end subroutine LogInterpolate
+
+  ! -- auxiliary numerical subroutines for interpolation/extrapolation from:
+  ! -- W. H. Press, S. A. Teukolsky, W. T. Vetterling, B. P. Flannery,
+  ! -- Numerical Recipes in Fortran 77: The Art of Scientific Computing
+  ! -- (Vol. 1 of Fortran Numerical Recipes), 2nd Ed., Cambridge Univ. Press
+  ! -- 
+
+  subroutine locate(xx, n, x, j)
+    implicit none
+    integer, intent(in) :: n
+    real(ESMF_KIND_R8), intent(in) :: x, xx(n)
+    integer, intent(out) :: j
+
+    ! -- local variables
+    integer :: jl, jm, ju
+
+    ! -- begin
+    jl = 0
+    ju = n + 1
+    do while (ju-jl.gt.1)
+      jm = (ju+jl)/2
+      if ((xx(n).ge.xx(1)).eqv.(x.ge.xx(jm))) then
+        jl = jm
+      else
+        ju = jm
+      end if
+    end do
+    if (x.eq.xx(1)) then
+      j = 1
+    else if (x.eq.xx(n)) then
+      j = n - 1
+    else
+      j = jl
+    end if
+
+  end subroutine locate
+
+  subroutine polint(xa, ya, n, x, y, dy, rc)
+
+    implicit none
+
+    integer, intent(in) :: n
+    real(ESMF_KIND_R8),    intent(in) :: xa(n), ya(n)
+    real(ESMF_KIND_R8),    intent(in) :: x
+    real(ESMF_KIND_R8),   intent(out) :: y, dy
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    integer, parameter :: nmax = 10
+    integer :: i, m, ns
+    real(ESMF_KIND_R8) :: den, dif, dift, ho, hp, w
+    real(ESMF_KIND_R8), dimension(nmax) :: c, d
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    ns = 1
+    dif = abs(x - xa(1))
+    do i = 1, n
+      dift = abs(x - xa(i))
+      if (dift < dif) then
+        ns  = i
+        dif = dift
+      end if
+      c(i) = ya(i)
+      d(i) = ya(i)
+    end do
+    y = ya(ns)
+    ns = ns - 1
+    do m = 1, n - 1
+      do i = 1, n - m
+        ho = xa(i)   - x
+        hp = xa(i+m) - x
+        w  = c(i+1)-d(i)
+        den = ho - hp
+        if (den == 0.) then
+          rc = ESMF_FAILURE
+          exit
+        end if
+        den = w / den
+        d(i) = hp * den
+        c(i) = ho * den
+      end do
+      if (2*ns < n - m) then
+        dy = c(ns+1)
+      else
+        dy = d(ns)
+        ns = ns - 1
+      end if
+      y = y + dy
+    end do
+
+  end subroutine polint
+
+  subroutine FieldRegrid(rh, fieldName, rc)
+
+    type(rhType)                  :: rh
+    character(len=*),  intent(in) :: fieldName
+    integer, optional, intent(out) :: rc
+
+    ! -- local variables
+    type(ESMF_Field) :: srcField, dstField
+    integer :: localrc
+    integer :: localDeCount
+    logical, save :: first = .true.
+
+    ! -- begin 
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    write(6,'("-- FieldRegrid: entering ...")')
+    
+    write(6,'("-- FieldRegrid: getting src field ",a,"(",a,")")') trim(fieldName), trim(rh % label)
+    srcField = StateGetField(rh % srcState, fieldName, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    call ESMF_FieldGet(srcField, localDeCount=localDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    write(6,'("-- FieldRegrid: got src field ",a,"(",a,") on ",i0," DEs")') trim(fieldName), trim(rh % label), localDeCount
+
+    write(6,'("-- FieldRegrid: getting dst field ",a,"(",a,")")') trim(fieldName), trim(rh % label)
+    dstField = StateGetField(rh % dstState, fieldName, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    call ESMF_FieldGet(srcField, localDeCount=localDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    write(6,'("-- FieldRegrid: got dst field ",a,"(",a,") on ",i0," DEs")') trim(fieldName), trim(rh % label), localDeCount
+
+    if (first) then
+      call ESMF_FieldFill(srcField, dataFillScheme="one", rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      first = .false.
+    end if
+    ! -- print diagnostic info
+    call FieldPrintMinMax(srcField, "pre  - src:" // trim(fieldName), rc)
+    call FieldPrintMinMax(dstField, "pre  - dst:" // trim(fieldName), rc)
+
+    write(6,'("-- FieldRegrid: ",a,"(",a,")")') trim(fieldName), trim(rh % label)
+    call ESMF_FieldRegrid(srcField=srcField, dstField=dstField, &
+!     zeroregion=ESMF_REGION_SELECT, &
+      zeroregion=ESMF_REGION_TOTAL, &
+      routehandle=rh % rh, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    write(6,'("-- FieldRegrid: ",a,"(",a,") done")') trim(fieldName), trim(rh % label)
+
+    ! -- print diagnostic info
+    call FieldPrintMinMax(srcField, "post - src:" // trim(fieldName), rc)
+    call FieldPrintMinMax(dstField, "post - dst:" // trim(fieldName), rc)
+
+    write(6,'("-- FieldRegrid: storing src field ",a,"(",a,")")') trim(fieldName), trim(rh % label)
+    call StateStoreField(rh % srcState, srcField, fieldName, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    write(6,'("-- FieldRegrid: done src field ",a,"(",a,")")') trim(fieldName), trim(rh % label)
+
+    write(6,'("-- FieldRegrid: storing dst field ",a,"(",a,")")') trim(fieldName), trim(rh % label)
+    call StateStoreField(rh % dstState, dstField, fieldName, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    write(6,'("-- FieldRegrid: done dst field ",a,"(",a,")")') trim(fieldName), trim(rh % label)
+
+  end subroutine FieldRegrid
+
+  function StateGetField(state, fieldName, auxArray, options, rc)
+
+    ! -- input variables
+    type(stateType),   intent(in)  :: state
+    character(len=*),  intent(in)  :: fieldName
+    type(ESMF_Array), optional, intent(in)  :: auxArray
+    character(len=*), optional, intent(in)  :: options
+
+    ! -- output 
+    type(ESMF_Field)               :: StateGetField
+    integer, optional, intent(out) :: rc
+
+    ! -- local variable
+    logical :: isFieldCreated
+    logical :: isNoData
+    integer :: localrc
+    integer :: localDeCount
+    type(ESMF_Field) :: field
+    type(ESMF_StateIntent_Flag) :: stateIntent
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    write(6,'("-- StateGetField: entering ...")')
+    isNoData = .false.
+    if (present(options)) then
+      isNoData = (trim(options) == "nodata")
+    end if
+
+    call ESMF_StateGet(state % parent, stateintent=stateIntent, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+
+    write(6,'("-- StateGetField: checking if field is created ...")')
+    isFieldCreated = ESMF_FieldIsCreated(state % localField, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+
+    if (isFieldCreated) then
+    write(6,'("-- StateGetField: field IS created")')
+      StateGetField = state % localField
+      write(6,'(" - StateGetField: field is local")')
+      if (isNoData) return
+      if (stateIntent == ESMF_STATEINTENT_IMPORT) then
+        write(6,'(" - StateGetField: state is Import: getting field from state ...")')
+        call ESMF_StateGet(state % self, itemName=trim(fieldName), field=field, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+        call ESMF_FieldGet(field, localDeCount=localDeCount, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+        write(6,'(" - StateGetField: got field from state ... with deCount = ",i0)') localDeCount
+        write(6,'(" - StateGetField: is remote levels? ",l6)') ESMF_ArrayIsCreated(state % remoteLevels)
+        call FieldInterpolate(field, StateGetField, srcLevels=state % remoteLevels, &
+          auxArray=auxArray, options=options, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+        write(6,'(" - StateGetField: interpolation is done")')
+      else if (stateIntent == ESMF_STATEINTENT_EXPORT) then
+        write(6,'(" - StateGetField: state is Export: not sure what to do...")') 
+      else
+        write(6,'(" - StateGetField: state is ??: not sure what to do...")') 
+      endif
+    else
+    write(6,'("-- StateGetField: field IS NOT created")')
+      call ESMF_StateGet(state % self, itemName=trim(fieldName), field=StateGetField, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+      write(6,'(" - RHStore: field is remote")')
+    end if
+
+  end function StateGetField
+
+  subroutine StateStoreField(state, field, fieldName, rc)
+
+    ! -- input variables
+    type(stateType),   intent(in)  :: state
+    type(ESMF_Field),  intent(in)  :: field
+    character(len=*),  intent(in)  :: fieldName
+
+    ! -- output 
+    integer, optional, intent(out) :: rc
+
+    ! -- local variable
+    integer :: localrc
+    type(ESMF_Field) :: dstField
+    type(ESMF_StateIntent_Flag) :: stateIntent
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    if (field == state % localField) then
+
+      call ESMF_StateGet(state % parent, stateintent=stateIntent, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+
+      if (stateIntent == ESMF_STATEINTENT_EXPORT) then
+        call ESMF_StateGet(state % self, itemName=trim(fieldName), &
+          field=dstField, rc=localrc) 
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+
+        call FieldInterpolate(field, dstField, dstLevels=state % remoteLevels, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+      end if
+
+    end if
+
+  end subroutine StateStoreField
+
+  subroutine FieldInterpolate(srcField, dstField, srcLevels, dstLevels, auxArray, options, rc)
+    type(ESMF_Field),            intent(in) :: srcField
+    type(ESMF_Field),         intent(inout) :: dstField
+    type(ESMF_Array), optional,  intent(in) :: srcLevels
+    type(ESMF_Array), optional,  intent(in) :: dstLevels
+    type(ESMF_Array), optional,  intent(in) :: auxArray
+    character(len=*), optional,  intent(in) :: options
+    integer,          optional, intent(out) :: rc
+
+    ! -- local variables
+    integer :: localrc
+    integer :: rank
+    integer :: srcDeCount, dstDeCount, auxDeCount, localDe
+    real(ESMF_KIND_R8), dimension(:,:,:), pointer :: srcData,  dstData, auxData
+    real(ESMF_KIND_R8), dimension(:,:,:), pointer :: srcCoord, dstCoord
+    type(ESMF_Grid)  :: srcGrid, dstGrid
+    type(ESMF_Array) :: srcCoordArray, dstCoordArray
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    write(6,'(" - FieldInterpolate: entering ...")')
+    write(6,'(" - FieldInterpolate: getting src field rank ...")')
+    call ESMF_FieldGet(srcField, grid=srcGrid, rank=rank, &
+      localDeCount=srcDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    write(6,'(" - FieldInterpolate: got src field rank = ",i6)') rank
+    write(6,'(" - FieldInterpolate: got src field localDeCount = ",i6)') srcDeCount
+
+    if (rank /= 3) then
+      call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+        msg="Source field's rank must be 3", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    write(6,'(" - FieldInterpolate: getting dst field rank ...")')
+    call ESMF_FieldGet(dstField, grid=dstGrid, rank=rank, &
+      localDeCount=dstDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) return  ! bail out
+    write(6,'(" - FieldInterpolate: got dst field rank = ",i6)') rank
+    write(6,'(" - FieldInterpolate: got dst field localDeCount = ",i6)') dstDeCount
+
+    if (rank /= 3) then
+      call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+        msg="Source field's rank must be 3", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    if (srcDeCount /= dstDeCount) then
+      call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+        msg="localDeCount of source and destination field must match", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+
+    if (present(srcLevels)) then
+      call ESMF_ArrayGet(srcLevels, rank=rank, localDeCount=dstDeCount, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+      if (rank /= 3) then
+        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+          msg="Rank of source levels array must be 3", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if
+      if (srcDeCount /= dstDeCount) then
+        call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+          msg="srcLevels and srcField must have equal localDeCount", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if
+      srcCoordArray = srcLevels
+    else
+      write(6,'(" - FieldInterpolate: get src levels from src grid ...")')
+      call ESMF_GridGetCoord(srcGrid, coordDim=3, &
+        staggerloc=ESMF_STAGGERLOC_CENTER, array=srcCoordArray, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      write(6,'(" - FieldInterpolate: got src levels from src grid ")')
+    end if
+
+    if (present(dstLevels)) then
+      call ESMF_ArrayGet(dstLevels, rank=rank, localDeCount=dstDeCount, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+      if (rank /= 3) then
+        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+          msg="Rank of destination levels array must be 3", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if
+      if (srcDeCount /= dstDeCount) then
+        call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+          msg="dstLevels and dstField must have equal localDeCount", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if
+      dstCoordArray = dstLevels
+    else
+      write(6,'(" - FieldInterpolate: get src levels from src grid ...")')
+      call ESMF_GridGetCoord(dstGrid, coordDim=3, &
+        staggerloc=ESMF_STAGGERLOC_CENTER, array=dstCoordArray, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return
+      write(6,'(" - FieldInterpolate: got src levels from src grid ")')
+    end if
+
+    if (present(auxArray)) then
+      call ESMF_ArrayGet(auxArray, rank=rank, localDeCount=auxDeCount, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+      if (rank /= 3) then
+        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+          msg="Rank of auxiliary array must be 3", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if
+      if (srcDeCount /= auxDeCount) then
+        call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+          msg="auxField must have localDeCount equal to srcField & dstField", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end if
+    end if
+
+    do localDe = 0, srcDeCount - 1
+
+      call ESMF_FieldGet(srcField, localDE=localDe, farrayPtr=srcData, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+
+      call ESMF_ArrayGet(srcCoordArray, localDE=localDe, farrayPtr=srcCoord, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+
+      call ESMF_FieldGet(dstField, localDE=localDe, farrayPtr=dstData, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+
+      call ESMF_ArrayGet(dstCoordArray, localDE=localDe, farrayPtr=dstCoord, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+
+      if (present(auxArray)) then
+        call ESMF_ArrayGet(auxArray, localDE=localDe, farrayPtr=auxData, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+      else
+        nullify(auxData)
+      end if
+
+      call Interpolate(srcCoord, srcData, dstCoord, dstData, &
+        auxfarray=auxData, options=options, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+
+    end do
+
+  end subroutine FieldInterpolate
+
+  subroutine FieldPrintMinMax(field, label, rc)
+    type(ESMF_Field)                        :: field
+    character(len=*), optional,  intent(in) :: label
+    integer,          optional, intent(out) :: rc
+
+    ! -- local variables
+    integer :: localrc, rank
+    integer :: localDe, localDeCount
+    character(len=ESMF_MAXSTR) :: name
+    real(ESMF_KIND_R8), pointer :: fptr1d(:), fptr2d(:,:), fptr3d(:,:,:)
+    real(ESMF_KIND_R8) :: fmin, fmax, fieldMin, fieldMax
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    fieldMin = huge(0._ESMF_KIND_R8)
+    fieldMax = -fieldMin
+
+    call ESMF_FieldGet(field, name=name, rank=rank, localDeCount=localDeCount, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    do localDe = 0, localDeCount - 1
+      select case (rank)
+      case(1)
+        call ESMF_FieldGet(field, farrayPtr=fptr1d, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+        fmin = minval(fptr1d)
+        fmax = maxval(fptr1d)
+      case(2)
+        call ESMF_FieldGet(field, farrayPtr=fptr2d, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+        fmin = minval(fptr2d)
+        fmax = maxval(fptr2d)
+      case(3)
+        call ESMF_FieldGet(field, farrayPtr=fptr3d, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+        fmin = minval(fptr3d)
+        fmax = maxval(fptr3d)
+      case default
+        call ESMF_LogSetError(ESMF_RC_OBJ_BAD, &
+          msg="Rank must be 1, 2, or 3 for field "//trim(name), &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return ! bail out
+      end select
+      fieldMin = min(fieldMin, fmin)
+      fieldMax = max(fieldMax, fmax)
+    end do
+
+    write(6,'("FieldPrintMinMax: ",a,1x,a," min = ",g14.6," max = ",g14.6)') &
+      trim(label), trim(name), fieldMin, fieldMax
+
+  end subroutine FieldPrintMinMax
+
+  ! -- Namespace: Field Retrieve/Store/Interpolate/Release methods: end definition --
+
+  ! -- Namespace: Utilities: begin definition --
+
+  subroutine NamespacePrint(rc)
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),     pointer :: p
+    type(stateType),    pointer :: s
+    type(ESMF_StateIntent_Flag) :: stateintent
+    character(len=ESMF_MAXSTR)  :: stateName
+    integer :: i, localPet
+    type(ESMF_VM) :: vm
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    call ESMF_VMGetCurrent(vm, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call ESMF_VMGet(vm, localPet=localPet, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    if (localPet /= 0) return
+
+    nullify(s)
+    print *,'Printing namespace...'
+    print *,'====================='
+    p => compList
+    do while (associated(p))
+      print *,'Namespace: ', trim(p % name)
+      s => p % stateList
+      do while (associated(s))
+        call ESMF_StateGet(s % parent, stateintent=stateintent, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+        call ESMF_StateGet(s % self, name=stateName, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+        if (stateintent == ESMF_STATEINTENT_IMPORT) then
+          print *,"State: ",trim(stateName), ": Import"
+        else if (stateintent == ESMF_STATEINTENT_EXPORT) then
+          print *,"State: ",trim(stateName), ": Export"
+        else if (stateintent == ESMF_STATEINTENT_UNSPECIFIED) then
+          print *,"State: ",trim(stateName), ": Intent unspecified"
+        else
+          print *,"State: ",trim(stateName), ": Intent N/A"
+        end if
+        if (associated(s % fieldNames)) then
+          do i = 1, size(s % fieldNames)
+            print *,i,trim(s % fieldNames(i))
+          end do
+        else
+          print *,'No fields attached'
+        end if
+        if (associated(s % fieldOptions)) then
+          do i = 1, size(s % fieldOptions)
+            print *,i,trim(s % fieldOptions(i))
+          end do
+        else
+          print *,'No field options attached'
+        end if
+        if (s % ugDimLength /= 0) then
+          print *,'Length of ungridded dimension: ', s % ugDimLength
+        else
+          print *,'No ungridded dimension'
+        end if
+        print *,'transferAction: ', trim(s % trAction)
+        s => s % next
+      end do
+      p => p % next
+    end do
+    print *,'====================='
+
+    nullify(p, s)
+
+  end subroutine NamespacePrint
+
+  ! -- Namespace: Utilities: end definition --
+
+  ! -- RouteHandle: begin definition --
+
+  function RouteHandleListGet(rc)
+    integer, optional, intent(out) :: rc
+
+    ! -- local variables
+    type(rhType),          pointer :: RouteHandleListGet
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    RouteHandleListGet => rhList
+
+  end function RouteHandleListGet
+
+  subroutine RouteHandleListSet(routeHandleList, rc)
+    integer, optional, intent(out) :: rc
+    type(rhType),          pointer :: routeHandleList
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    rhList => routeHandleList
+
+  end subroutine routeHandleListSet
+
+  logical function RouteHandleListIsCreated(rc)
+    integer, optional, intent(out) :: rc
+
+    ! -- begin
+    RouteHandleListIsCreated = associated(RouteHandleListGet(rc=rc))
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+  end function RouteHandleListIsCreated
+
+  subroutine RouteHandleCreate(routeHandle, rc)
+
+    type(rhType), optional,     pointer :: routeHandle
+    integer,      optional, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),     pointer :: p, q
+    type(stateType),    pointer :: r, s
+    type(rhType),       pointer :: rh, rHandle
+    type(ESMF_Field)            :: srcField, dstField
+    type(ESMF_StateIntent_flag) :: stateIntent
+    character(len=ESMF_MAXSTR)  :: srcName, dstName
+    integer                     :: localrc
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    rh => rhList
+    p => compList
+    do while (associated(p))
+      s => p % stateList
+      do while (associated(s))
+        call ESMF_StateGet(s % parent, stateintent=stateIntent, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+        if (stateIntent == ESMF_STATEINTENT_IMPORT) then
+          q => compList
+          do while (associated(q))
+            if (trim(p % name) /= trim(q % name)) then
+              r => q % stateList
+              do while (associated(r))
+                call ESMF_StateGet(r % parent, stateintent=stateIntent, rc=localrc)
+                if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                  line=__LINE__,  &
+                  file=__FILE__,  &
+                  rcToReturn=rc)) return  ! bail out
+
+                if (stateIntent == ESMF_STATEINTENT_EXPORT) then
+
+                  call ESMF_StateGet(s % self, name=srcName, rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__,  &
+                    file=__FILE__,  &
+                    rcToReturn=rc)) return  ! bail out
+
+                  call ESMF_StateGet(r % self, name=dstName, rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__,  &
+                    file=__FILE__,  &
+                    rcToReturn=rc)) return  ! bail out
+
+                  srcField = StateGetField(s, s % fieldNames(1), options="nodata", rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__,  &
+                    file=__FILE__,  &
+                    rcToReturn=rc)) return  ! bail out
+
+                  dstField = StateGetField(r, r % fieldNames(1), options="nodata", rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__,  &
+                    file=__FILE__,  &
+                    rcToReturn=rc)) return  ! bail out
+
+                  nullify(rHandle)
+                  allocate(rHandle, stat=localrc)
+                  if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__, &
+                    file=__FILE__, &
+                    rcToReturn=rc)) return ! bail out
+                  rHandle % label    = trim(srcName)//" -> "//trim(dstName)
+                  rHandle % srcState => s
+                  rHandle % dstState => r
+                  nullify(rHandle % next)
+
+                  write(6,'(" - RHStore: start working on RH ...",a)') trim(rHandle % label)
+!                 call ESMF_FieldRegridStore(srcField, dstField, &
+!                   regridmethod=ESMF_REGRIDMETHOD_BILINEAR, &
+!                   unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, &
+!                   ignoreDegenerate=.true., &
+!                   routehandle=rHandle % rh, rc=localrc)
+                  call ESMF_FieldRegridStore(srcField, dstField, &
+                    regridmethod   = ESMF_REGRIDMETHOD_BILINEAR, &
+                    unmappedaction = ESMF_UNMAPPEDACTION_IGNORE, &
+                    polemethod     = ESMF_POLEMETHOD_NONE,       &
+                    lineType       = ESMF_LINETYPE_GREAT_CIRCLE, &
+                    routehandle=rHandle % rh, rc=localrc)
+                  if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+                    line=__LINE__,  &
+                    file=__FILE__,  &
+                    rcToReturn=rc)) return  ! bail out
+                  write(6,'(" - RHStore: done working on RH ...",a)') trim(rHandle % label)
+
+                  if (associated(rh)) then
+                    rh % next => rHandle
+                  else
+                    rhList => rHandle
+                  end if
+                  rh => rHandle
+                end if 
+                r => r % next
+              end do
+            end if 
+            q => q % next
+          end do
+        end if
+        s => s % next
+      end do
+      p => p % next
+    end do
+
+    if (present(routeHandle)) routeHandle => rhList
+
+  end subroutine RouteHandleCreate
+
+  subroutine RouteHandlePrint(routeHandleList, detailed, rc)
+    type(rhType), optional, pointer     :: routeHandleList
+    logical,      optional,  intent(in) :: detailed
+    integer,      optional, intent(out) :: rc
+
+    ! -- local variables
+    integer :: item, localrc
+    type(rhType), pointer :: rh
+
+    logical :: printDetails
+    integer :: localPet
+    type(ESMF_VM) :: vm
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    printDetails = .false.
+    if (present(detailed)) printDetails = detailed
+
+    call ESMF_VMGetCurrent(vm, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    call ESMF_VMGet(vm, localPet=localPet, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__, &
+      rcToReturn=rc)) return  ! bail out
+
+    if (present(routeHandleList)) then
+      rh => routeHandleList
+    else
+      rh => rhList
+    end if
+
+    print *, 'RouteHandle Table'
+    print *, '================='
+    item = 0
+    do while (associated(rh))
+      item = item + 1
+      write(6,'(i4,2x,a,2x,l5)') item, trim(rh % label), &
+        ESMF_RouteHandleIsCreated(rh % rh, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return  ! bail out
+      if (printDetails) then
+        call ESMF_RouteHandlePrint(rh % rh, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)) return  ! bail out
+      end if
+      rh => rh % next
+    end do
+    print *, '================='
+    
+  end subroutine RouteHandlePrint
+
+  subroutine RouteHandleListRelease(routeHandleList, rc)
+
+    type(rhType), optional, pointer     :: routeHandleList
+    integer,      optional, intent(out) :: rc
+
+    ! -- local variables
+    type(compType),  pointer :: p, q
+    type(stateType), pointer :: s, r
+    type(rhType),    pointer :: rh, lh
+    integer                  :: localrc
+    logical                  :: isRHCreated
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    ! -- free up memory
+    ! -- routehandles
+    if (present(routeHandleList)) then
+      rh => routeHandleList
+    else
+      rh => rhList
+    end if
+
+    do while (associated(rh))
+      lh => rh
+      rh => rh % next
+      isRHCreated = ESMF_RouteHandleIsCreated(lh % rh, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) return  ! bail out
+      if (isRHCreated) then
+        call ESMF_FieldRegridRelease(lh % rh, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) return  ! bail out
+      end if
+      deallocate(lh, stat=localrc)
+      if (ESMF_LogFoundAllocError(statusToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)) return ! bail out
+      nullify(lh)
+    end do
+
+    if (present(routeHandleList)) then
+      nullify(routeHandleList)
+    else
+      nullify(rhList)
+    end if
+
+  end subroutine RouteHandleListRelease
+
+  ! -- RouteHandle: end definition --
+
+
+  !-----------------------------------------------------------------------------
+  !-----------------------------------------------------------------------------
+  ! Peggy's routines below....
+  !-----------------------------------------------------------------------------
+  !-----------------------------------------------------------------------------
+
+  subroutine initGrids(model, wam2dMesh, wamMesh, minheight, heights, rc)
+
+#ifdef ESMF_NETCDF
+    use netcdf
+#endif
+    
+    type(ESMF_GridComp)  :: model
+    type(ESMF_MESH) :: wam2dmesh, wamMesh
+    real(ESMF_KIND_R8), optional, intent(in) :: minheight
+    real(ESMF_KIND_R8), optional, intent(in) :: heights(:)
+    integer, intent(out) :: rc
+
+
+  type(ESMF_VM) :: vm
+#if 0
+  type(InternalState)     :: is
+  type(ESMF_MESH) :: wammesh
+#endif
+  real(ESMF_KIND_R8), pointer :: wamlon(:,:), wamlat(:,:), wamhgt(:)
+  real(ESMF_KIND_R8), pointer :: ipelon(:,:), ipelat(:,:), ipehgt(:), ipedata(:)
+  real(ESMF_KIND_R8), pointer :: hgtbuf(:,:,:), varbuf(:,:,:,:)
+  real(ESMF_KIND_R8), pointer :: databuf(:)
+  integer(ESMF_KIND_I4), pointer :: maxlevs(:)
+  integer(ESMF_KIND_I4), pointer :: numPerRow(:), shuffleOrder(:)
+  integer :: nc1, ncid
+  integer :: varid, dimid1, dimid2, dimid3
+  integer :: ndims, dimids(3)
+  integer :: wamdims(3), ipedims(3)
+  integer :: PetNo, PetCnt
+  integer(ESMF_KIND_I4), pointer :: elementIds(:), elementTypes(:), elementConn(:)
+  integer(ESMF_KIND_I4), pointer :: nodeIds(:), nodeOwners(:)
+  real(ESMF_KIND_R8), pointer :: nodeCoords(:)
+  integer(ESMF_KIND_I4), pointer :: southind(:), northind(:), totallats(:), gap(:)
+! integer :: minheight, maxheight, halo, neighbor, remind
+  integer :: halo, neighbor, remind
+  integer(ESMF_KIND_I4), pointer :: totalheight(:)
+  real(ESMF_KIND_R8) :: lon, lat, hgt, lon1, lat1, hgt1
+  real(ESMF_KIND_R4) :: interval
+  integer :: i,j, k, l, ii, jj, kk, count1, count3, count8, localcount, countup, save, base, base1
+  logical :: even
+  integer :: start, count, diff, lastlat, totalelements, totalnodes, localnodes, startid
+  integer :: wamtotalnodes
+  integer :: elmtcount, increment
+  integer :: startlevel, next, ind, ind1, totalnodes2d, totallevels, myrows, trigs
+  integer :: reminder, steps, startrow, startnode
+  integer, pointer :: rowinds(:), petTable(:), baseind(:)
+  integer(ESMF_KIND_I4), pointer :: elementCnt(:), nodeCnt(:), sendbuf(:), recvbuf(:)
+  integer(ESMF_KIND_I4), allocatable :: indList(:)
+  real(ESMF_KIND_R8), pointer :: conntbl(:), globalCoords(:,:), fptr2d(:,:), fptr1d(:)
+  type(ESMF_Arrayspec) :: arrayspec
+  type(ESMF_Array) :: array, array1, array2
+  real(ESMF_KIND_R8) :: maxerror, minerror, totalerrors, deg2rad
+  real(ESMF_KIND_R8) :: starttime, endtime, timesend(1), timereport(1)
+  real(ESMF_KIND_R8) :: differr
+  real(ESMF_KIND_R8) :: lminheight
+  real(ESMF_KIND_R8), pointer :: varout(:), lonbuf(:),latbuf(:)
+  real(ESMF_KIND_R8), pointer :: weights(:)
+  integer(ESMF_KIND_I4), pointer :: indices(:,:)
+  character(len=ESMF_MAXSTR) :: wamfilename
+  character(len=ESMF_MAXSTR) :: filename
+  integer :: wgtcount(1)
+  integer :: count2(1), start2(1)
+  integer, pointer :: allCounts(:), connectbase(:)
+  real, parameter :: PI=3.1415927
+  integer :: j1
+  integer :: localrc, status
+  real, parameter :: earthradius=6371.0  !in kilometers
+
+  ! For output
+  real(ESMF_KIND_R8), pointer :: lontbl(:), lattbl(:), hgttbl(:)
+  integer :: lonid, latid, hgtid, vertid, elmtid, nodeid, numid, connid, timeid
+  integer :: data1id, data2id, wgtid, wamid, ipeid
+  integer :: globalTotal, globalTotalelmt, nodestartid, totalwgts
+  type(ESMF_Distgrid) :: nodalDistgrid, distgrid
+
+  rc = ESMF_SUCCESS
+
+  !------------------------------------------------------------------------
+  ! get global vm information
+  !
+  call ESMF_VMGetCurrent(vm, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+  ! set up local pet info
+  call ESMF_VMGet(vm, localPet=PetNo, petCount=PetCnt, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+#if 0
+  !------------------------------------------------------------------------
+  ! Allocate memory for the internal state and set it in the Component.
+    allocate(is%wrap, stat=rc)
+    if (ESMF_LogFoundAllocError(statusToCheck=rc, &
+      msg="Allocation of the internal state memory failed.", &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    call ESMF_GridCompSetInternalState(model, is, rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+#endif
+
+  !wamfilename = 'data/wam3dgridnew.nc'
+  wamfilename = 'wam3dgridnew_20160427.nc'
+  filename = 'wam2dmesh.nc'
+! minheight = 90.
+! maxheight = 782.
+  deg2rad = PI/180.0
+
+#ifdef ESMF_NETCDF
+  !!-------------------------------------
+  !! Create WAM mesh
+  !!-------------------------------------
+  ! We need to create a 2D mesh with distgrid only and use it to get the data
+  ! from the DATAWAM
+  ! we also need to create the 3D intermediate WAM mesh to be used to regrid
+  ! with IPE grid
+ 
+  ! Read in WAM grid from wam3dgrid.nc
+  !!
+  status = nf90_open(path= wamfilename, mode=nf90_nowrite, ncid=nc1)
+  call CheckNCError(status, wamfilename)
+  status = nf90_inq_varid(nc1,'lons', varid)
+  call CheckNCError(status, 'lons')
+  status = nf90_inquire_variable(nc1, varid, ndims=ndims, dimids = dimids)
+  call CheckNCError(status, 'lons')
+  status = nf90_inquire_dimension(nc1,dimids(1), len=wamdims(1))
+  call CheckNCError(status, 'lons 1st dimension')
+  status = nf90_inquire_dimension(nc1,dimids(2), len=wamdims(2))
+  call CheckNCError(status, 'lons 2nd dimension')
+
+  ! WAM dimension order:  lons, lats (192, 94)
+  allocate(wamlon(wamdims(1), wamdims(2)), &
+  	   wamlat(wamdims(1), wamdims(2)))
+  status = nf90_get_var(nc1, varid, wamlon)
+  call CheckNCError(status, 'lons')
+  status = nf90_inq_varid(nc1,'lats', varid)
+  call CheckNCError(status, 'lats')
+  status = nf90_get_var(nc1, varid, wamlat)
+  call CheckNCError(status, 'lats')
+
+  ! intermediate height fields
+  if (present(heights)) then
+    wamdims(3) = size(heights)
+    allocate(wamhgt(wamdims(3)))
+    wamhgt = heights
+  else
+    status = nf90_inq_varid(nc1,'height', varid)
+    call CheckNCError(status, 'height')
+    status = nf90_inquire_variable(nc1, varid, ndims=ndims, dimids = dimids)
+    call CheckNCError(status, 'height')
+    status = nf90_inquire_dimension(nc1,dimids(1), len=wamdims(3))
+    call CheckNCError(status, 'height 1st dimension')
+
+    allocate(wamhgt(wamdims(3)))
+    status = nf90_get_var(nc1, varid, wamhgt)
+    call CheckNCError(status, 'height')
+  end if
+
+  allocate(NumPerRow(wamdims(2)), ShuffleOrder(wamdims(2)))
+  status = nf90_inq_varid(nc1,'NumPerRow', varid)
+  call CheckNCError(status, 'NumPerRow')
+  status = nf90_get_var(nc1, varid, NumPerRow)
+  call CheckNCError(status, 'NumPerRow')
+  status = nf90_inq_varid(nc1,'ShuffleOrder', varid)
+  call CheckNCError(status, 'ShuffleOrder')
+  status = nf90_get_var(nc1, varid, ShuffleOrder)
+  call CheckNCError(status, 'ShuffleOrder')
+  status= nf90_close(nc1)
+  call CheckNCError(status, wamfilename)
+
+  ! Use the shuffle order to create the 2D mesh first
+  ! find the total number of nodes in each processor and create local index table
+  localnodes=0
+  myrows = wamdims(2)/PetCnt
+#if 0
+  if ((wamdims(2)-myrows*PetCnt) > PetNo) myrows = myrows+1
+  allocate(rowinds(myrows))      !my local row index
+  allocate(petTable(wamdims(2))) !the owner PET for each row
+  next = 0
+  ind1 = 0
+  do i=1,wamdims(2)
+    ind=ShuffleOrder(i)
+    petTable(ind)=next
+    if (next == PetNo) then
+       ind1=ind1+1
+       rowinds(ind1)=ind
+       localnodes=localnodes + numPerRow(ind)
+    endif
+    next=next+1
+    if (next == PetCnt) next=0
+  enddo
+  print *, PetNo, 'localnodes/myrows:', localnodes, myrows
+#else
+  reminder = wamdims(2)-myrows*PetCnt
+  if (reminder > PetNo)  then
+     myrows = myrows+1
+     startrow = myrows*PetNo+1
+  else
+     startrow = myrows*PetNo + reminder+1
+  endif
+  allocate(rowinds(myrows))      !my local row index
+  allocate(petTable(wamdims(2))) !the owner PET for each row
+  do i=1,myrows
+    rowinds(i)=ShuffleOrder(startrow+i-1)
+    localnodes = localnodes + numPerRow(rowinds(i))
+  enddo
+  print *, PetNo, 'start rows:', startrow, localnodes, myrows
+  ind1 = 1
+  steps = wamdims(2)/PetCnt
+  do next=0,PetCnt-1
+    if (next<reminder) then
+       do i=ind1, ind1+steps
+          PetTable(ShuffleOrder(i))=next
+       enddo
+       ind1 = ind1+steps+1
+    else
+       do i=ind1, ind1+steps-1
+          PetTable(ShuffleOrder(i))=next
+       enddo
+       ind1 = ind1+steps
+    endif
+  enddo
+  if (ind1 /= wamdims(2)+1) then
+     print *, 'MEDIATOR Wrong ind1 ', ind1, wamdims(2)
+  endif
+#endif
+  
+  ! sort rowinds
+  call ESMF_UtilSort(rowinds, ESMF_SORTFLAG_ASCENDING, rc)
+
+  print *, PetNo, 'sorted rowinds ', rowinds
+
+  ! Save the lat/lon in the order the distgrid
+  allocate(lonbuf(localnodes), latbuf(localnodes))
+
+  ! Create a distgrid using a collapsed 1D index array based on the local row index
+  allocate(indList(localnodes))
+  k=1
+  do i=1,myrows
+    ind=rowinds(i)
+    do j=1,numPerRow(ind)
+       indList(k)=(ind-1)*wamdims(1)+j
+       lonbuf(k)=wamlon(j,ind)
+       latbuf(k)=wamlat(j,ind)
+       k=k+1
+    enddo
+  enddo
+
+  ! write out the index into a NetCDF file
+  ! find the total nodes first
+  totalnodes = sum(numPerRow)
+  ! find out starting node id
+  startnode = 1
+  do i=1,startrow-1
+    startnode = startnode+numPerRow(ShuffleOrder(i))
+  enddo
+  call ESMF_VMBarrier(vm)
+
+  distgrid = ESMF_DistGridCreate(indList, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+  ! Create mesh using the distgrid as the nodaldistgrid,  no elemdistgrid available
+  ! just use nodeldistgrid for both
+  wam2dmesh = ESMF_MeshCreate(distgrid,distgrid,rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+  
+  ! Create the 3D mesh with fixed height
+  ! find the lower height level where height > minheight
+  lminheight = 0._ESMF_KIND_R8
+  if (present(minheight)) lminheight = minheight
+  allocate(nodeCoords(3))
+  do i=1,wamdims(3)
+     call convert2Cart(0._ESMF_KIND_R8, 0._ESMF_KIND_R8, wamhgt(i), nodeCoords)
+!    if (wamhgt(i) > minheight) then
+     if (nodeCoords(3) > lminheight) then
+    	startlevel = i-1
+	exit
+     endif
+  enddo
+  deallocate(nodeCoords)
+  totallevels = wamdims(3)-startlevel+1
+
+  if (PetNo == 0) then
+    ! create the output file
+    status = nf90_create(filename, NF90_CLOBBER, ncid)
+    call CheckNCError(status, filename)
+    status = nf90_def_dim(ncid, 'nodes', totalnodes, dimid1)
+    call CheckNCError(status, 'dimension nodes')
+    status = nf90_def_dim(ncid, 'levels', totallevels, dimid2)
+    call CheckNCError(status, 'dimension nodes')
+    status = nf90_def_dim(ncid, 'vars', 7, dimid3)
+    call CheckNCError(status, 'dimension nodes')
+    status = nf90_def_var(ncid, 'lons', NF90_FLOAT, (/dimid1/), varid)
+    call CheckNCError(status, 'variable lons')
+    status = nf90_def_var(ncid, 'lats', NF90_FLOAT, (/dimid1/), varid)
+    call CheckNCError(status, 'variable lats')
+    status = nf90_def_var(ncid, 'wamdata', NF90_FLOAT, (/dimid1, dimid2, dimid3/), varid)
+    call CheckNCError(status, 'variable wamdata')
+    status = nf90_close(ncid)
+    call CheckNCError(status, filename)
+  endif
+
+  ! write out the lat/lon from each processor
+  do i=0, PetCnt-1
+    if (PetNo == i) then
+      status = nf90_open(filename, NF90_WRITE, ncid)
+      call CheckNCError(status, filename)
+      count2(1)=localnodes
+      start2(1)=startnode
+      status = nf90_inq_varId(ncid, 'lons', varid)
+      call CheckNCError(status, 'lons')
+      status = nf90_put_var(ncid, varid, lonbuf, & 
+		    start2, count2)
+      call CheckNCError(status, 'lons')
+      status = nf90_inq_varId(ncid, 'lats', varid)
+      call CheckNCError(status, 'lats')
+      status = nf90_put_var(ncid, varid, latbuf, & 
+		    start2, count2)
+      call CheckNCError(status, 'lats')
+      status = nf90_close(ncid)
+      call CheckNCError(status, filename)
+    endif
+    call ESMF_VMBarrier(vm)
+  enddo
+  deallocate(lonbuf, latbuf)
+
+  ! create the node table, find the total number of nodes in each processor, including the not-owned node
+  totalnodes=0
+  totalelements=0 
+  allocate(baseind(myrows))
+  do i=1,myrows
+     ind=rowinds(i)
+     baseind(i)=totalnodes
+     ! Add the neighbor nodes
+     ! If PetCnt==1, no need to add neighbor node
+     ! If last row, no need to add neighbors
+     ! If the neighbor is local, no need to add
+     if (ind < wamdims(2)) then
+       if (PetCnt>1) then
+        if ((i < myrows .and. rowinds(i+1) /= ind+1) .or. i==myrows) then
+          totalnodes=totalnodes+numPerRow(ind)+numPerRow(ind+1)
+        else
+          totalnodes=totalnodes+numPerRow(ind)
+        endif
+       endif
+       if (numPerRow(ind) >= numPerRow(ind+1)) then
+         totalelements = totalelements + numPerRow(ind)
+       else
+         totalelements = totalelements + numPerRow(ind+1)
+       endif
+     else
+       totalnodes=totalnodes+numPerRow(ind)
+       !Add extra elements at the top
+       totalelements = totalelements+numPerRow(ind)-2
+     endif
+
+     ! Add extra elements for south pole
+      if (ind==1) then 
+        totalelements = totalelements+numPerRow(ind)-2
+     endif
+  enddo
+  if (PetCnt == 1) then
+     baseind(1)=0
+     do i=2,wamdims(2)
+       baseind(i)=baseind(i-1)+numPerRow(i-1)
+     enddo
+  endif
+
+  totalnodes2d=totalnodes  ! totalnodes includes neighboring nodes and my own nodes
+  totalnodes = totalnodes * totallevels 
+  localnodes = localnodes * totallevels  ! localnodes are locally owned nodes
+  totalelements = totalelements * (totallevels-1)
+  allocate(nodeIds(totalnodes), nodeOwners(totalnodes), nodeCoords(totalnodes*3))
+
+  ! Fill nodeIds, nodeOwners, and nodeCoords arrays, longitude first, latitude, then height
+  count1=1
+  localcount=1
+  count3=1
+  if (PetCnt > 1) then
+  do k=1, totallevels
+    do i=1,myrows
+       ind=rowinds(i)
+       do j=1,numPerRow(ind)
+          ! Global id based on the 3D indices
+       	  nodeIds(count1)= j+wamdims(1)*(ind-1)+wamdims(1)*wamdims(2)*(k-1)
+          nodeOwners(count1)=PetNo
+	  lon = wamlon(j,ind)
+          lat  = wamlat(j,ind)
+          hgt = wamhgt(startlevel+k-1)
+          call convert2Cart(lon, lat, hgt, nodeCoords(count3:count3+2))
+          count1=count1+1
+          localcount=localcount+1
+          count3=count3+3
+       enddo
+       ! if not the last row, add the neighbor row's nodes and the neighbor
+       ! is not local
+       if (ind < wamdims(2)) then
+         if (i==myrows .or. (i < myrows .and. rowinds(i+1)/= ind+1)) then
+       	  do j=1, numPerRow(ind+1)
+            ! Global id based on the 3D indices
+            nodeIds(count1)= j+wamdims(1)*ind+wamdims(1)*wamdims(2)*(k-1)
+	    if (PetTable(ind+1) == PetNo) then
+	       print *, PetNo, 'wrong neighbor ', count1, PetTable(ind+1)
+            endif
+            nodeOwners(count1)=PetTable(ind+1)
+	    lon = wamlon(j,ind+1)
+            lat  = wamlat(j,ind+1)
+            hgt = wamhgt(k+startlevel-1)
+            call convert2Cart(lon, lat, hgt, nodeCoords(count3:count3+2))
+            count1=count1+1
+            count3=count3+3
+          enddo
+         endif
+	endif
+     enddo
+  enddo
+  else ! PetCnt==1
+  ! For sequential case, store the rows in its order, do not shuffle
+  do k=1, totallevels
+    do ind=1,myrows
+       do j=1,numPerRow(ind)
+          ! Global id based on the 3D indices
+       	  nodeIds(count1)= j+wamdims(1)*(ind-1)+wamdims(1)*wamdims(2)*(k-1)
+          nodeOwners(count1)=PetNo
+	  lon = wamlon(j,ind)
+          lat  = wamlat(j,ind)
+          hgt = wamhgt(k+startlevel-1)
+          call convert2Cart(lon, lat, hgt, nodeCoords(count3:count3+2))
+          count1=count1+1
+          localcount=localcount+1
+          count3=count3+3
+       enddo
+     enddo
+  enddo
+  endif ! PetCnt > 1
+
+  if (count1-1 /= totalnodes .or. localcount-1 /= localnodes) then
+     print *, 'totalcount mismatch ', count1-1, totalnodes, localcount-1, localnodes
+  endif
+
+#ifdef USE_CART3D_COORDSYS
+  wamMesh = ESMF_MeshCreate(3,3,coordSys=ESMF_COORDSYS_CART, rc=rc)
+#else
+  wamMesh = ESMF_MeshCreate(3,3,coordSys=ESMF_COORDSYS_SPH_DEG, rc=rc)
+#endif
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+  call ESMF_MeshAddNodes(wamMesh, nodeIds, nodeCoords, nodeOwners, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+  
+  deallocate(wamlon, wamlat)
+  deallocate(nodeIds, nodeCoords, nodeOwners)
+
+  allocate(elementIds(totalelements), elementTypes(totalelements), &
+           elementConn(totalelements*8))
+
+  elementTypes(:)=ESMF_MESHELEMTYPE_HEX
+
+  ! find out the starting global id of the local element
+  allocate(elementCnt(PetCnt),sendbuf(1))
+  sendbuf(1)=totalelements
+  call ESMF_VMAllGather(vm, sendbuf, elementCnt, 1, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return  ! bail out
+  
+  ! find the starting elementID
+  startid=0
+  do i=1,PetNo
+    startid=startid+elementCnt(i)
+  enddo
+  globaltotalelmt = 0
+  do i=1,PetCnt
+    globaltotalelmt=globaltotalelmt+elementCnt(i)
+  enddo
+  deallocate(elementCnt, sendbuf)
+
+  ! Build the local elementConn table using local node indices
+  ! If PetCnt=1, no shuffle, the rows are in order
+  count1=1
+  count8=1
+  do k=1, totallevels-1
+    do i=1,myrows
+       if (PetCnt > 1) then
+           ind=rowinds(i)
+       else
+	   ind = i
+       endif
+       base = baseind(i)+totalnodes2d*(k-1)
+       if (ind == wamdims(2)) then
+#if 0
+         ! create dummy elements by connecting every other nodes to form a triangle to cover the pole
+         do j=1, numPerRow(ind)-2, 2
+       	   elementIds(count1)=startid+count1
+	   elementConn(count8)= base+j
+	   elementConn(count8+1)=base+j+1
+	   elementConn(count8+2)=base+j+2
+	   elementConn(count8+3)=base+j+2
+	   elementConn(count8+4)=base+totalnodes2d+j
+	   elementConn(count8+5)=base+totalnodes2d+j+1
+	   elementConn(count8+6)=base+totalnodes2d+j+2
+	   elementConn(count8+7)=base+totalnodes2d+j+2
+	   count1=count1+1
+	   count8=count8+8
+         enddo
+         ! Last one, connect it back to the first node 
+     	 elementIds(count1)=startid+count1
+	 elementConn(count8)= base+j
+	 elementConn(count8+1)=base+j+1
+	 elementConn(count8+2)=base+1
+	 elementConn(count8+3)=base+1
+	 elementConn(count8+4)=base+totalnodes2d+j
+	 elementConn(count8+5)=base+totalnodes2d+j+1
+	 elementConn(count8+6)=base+totalnodes2d+1
+	 elementConn(count8+7)=base+totalnodes2d+1
+	 count1=count1+1
+	 count8=count8+8
+         cycle       
+#else
+         ! using the zigzag method to create triangles that covers the pole
+         ! First half
+         do j=1, numPerRow(ind)/2-1
+       	   elementIds(count1)=startid+count1
+	   elementConn(count8)= base+j
+	   elementConn(count8+1)=base+j+1
+	   elementConn(count8+2)=base+numPerRow(ind)-j
+	   elementConn(count8+3)=base+numPerRow(ind)-j
+	   elementConn(count8+4)=base+totalnodes2d+j
+	   elementConn(count8+5)=base+totalnodes2d+j+1
+	   elementConn(count8+6)=base+totalnodes2d+numPerRow(ind)-j
+	   elementConn(count8+7)=base+totalnodes2d+numPerRow(ind)-j
+	   count1=count1+1
+	   count8=count8+8
+         enddo
+         ! second half
+         do j=numPerRow(ind)/2+1, numPerRow(ind)-1
+       	   elementIds(count1)=startid+count1
+	   elementConn(count8)= base+j
+	   elementConn(count8+1)=base+j+1
+	   elementConn(count8+2)=base+numPerRow(ind)-j
+	   elementConn(count8+3)=base+numPerRow(ind)-j
+	   elementConn(count8+4)=base+totalnodes2d+j
+	   elementConn(count8+5)=base+totalnodes2d+j+1
+	   elementConn(count8+6)=base+totalnodes2d+numPerRow(ind)-j
+	   elementConn(count8+7)=base+totalnodes2d+numPerRow(ind)-j
+	   count1=count1+1
+	   count8=count8+8
+         enddo	   
+         cycle
+#endif
+       endif
+
+      ! South pole
+      if (ind == 1) then
+         ! using the zigzag method to create triangles that covers the pole
+         ! First half
+         do j=1, numPerRow(ind)/2-1
+       	   elementIds(count1)=startid+count1
+	   elementConn(count8)= base+j
+	   elementConn(count8+1)=base+j+1
+	   elementConn(count8+2)=base+numPerRow(ind)-j
+	   elementConn(count8+3)=base+numPerRow(ind)-j
+	   elementConn(count8+4)=base+totalnodes2d+j
+	   elementConn(count8+5)=base+totalnodes2d+j+1
+	   elementConn(count8+6)=base+totalnodes2d+numPerRow(ind)-j
+	   elementConn(count8+7)=base+totalnodes2d+numPerRow(ind)-j
+	   count1=count1+1
+	   count8=count8+8
+         enddo
+
+	 ! Second half
+         do j=numPerRow(ind)/2+1, numPerRow(ind)-1
+       	   elementIds(count1)=startid+count1
+	   elementConn(count8)= base+j
+	   elementConn(count8+1)=base+j+1
+	   elementConn(count8+2)=base+numPerRow(ind)-j
+	   elementConn(count8+3)=base+numPerRow(ind)-j
+	   elementConn(count8+4)=base+totalnodes2d+j
+	   elementConn(count8+5)=base+totalnodes2d+j+1
+	   elementConn(count8+6)=base+totalnodes2d+numPerRow(ind)-j
+	   elementConn(count8+7)=base+totalnodes2d+numPerRow(ind)-j
+	   count1=count1+1
+	   count8=count8+8
+         enddo	   
+       endif
+
+       ! the two adjacent rows have the same number of points, elements are cubes
+       if (numPerRow(ind+1) == numPerRow(ind)) then
+         do j=1,numPerRow(ind)-1
+       	   elementIds(count1)=startid+count1
+	   elementConn(count8)= base+j
+	   elementConn(count8+1)=base+j+1
+	   elementConn(count8+2)=base+numPerRow(ind)+j+1
+	   elementConn(count8+3)=base+numPerRow(ind)+j
+	   elementConn(count8+4)=base+totalnodes2d+j
+	   elementConn(count8+5)=base+totalnodes2d+j+1
+	   elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+j+1
+	   elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+j
+	   count1=count1+1
+	   count8=count8+8
+         enddo
+         ! last one in the row, wrap around
+       	 elementIds(count1)=startid+count1
+	 elementConn(count8)= base+j
+	 elementConn(count8+1)=base+1
+	 elementConn(count8+2)=base+numPerRow(ind)+1
+	 elementConn(count8+3)=base+numPerRow(ind)+j
+	 elementConn(count8+4)=base+totalnodes2d+j
+	 elementConn(count8+5)=base+totalnodes2d+1
+	 elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+1
+	 elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+j
+	 count1=count1+1
+	 count8=count8+8
+       else
+         ! the number of nodes are different, make prism elements
+	 diff=numPerRow(ind)-numPerRow(ind+1)
+	 if (diff > 0) then 
+          ! make triangles with base at lower row
+          ! triangles will be evenly distributed
+	  interval = real(numPerRow(ind))/(diff+1)
+	  jj=1
+          trigs=1
+          do j=1,numPerRow(ind)-1
+ 	     if (j > trigs*interval) then
+!	     if (mod(j,increment)==0) then
+               ! triangles - base at bottom
+               trigs=trigs+1
+               elementIds(count1)=startid+count1
+	       elementConn(count8)= base+j
+	       elementConn(count8+1)=base+j+1
+	       elementConn(count8+2)=base+numPerRow(ind)+jj
+	       elementConn(count8+3)=base+numPerRow(ind)+jj
+	       elementConn(count8+4)=base+totalnodes2d+j
+	       elementConn(count8+5)=base+totalnodes2d+j+1
+	       elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+jj
+	       elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+jj
+             else
+               elementIds(count1)=startid+count1
+	       elementConn(count8)= base+j
+	       elementConn(count8+1)=base+j+1
+	       elementConn(count8+2)=base+numPerRow(ind)+jj+1
+	       elementConn(count8+3)=base+numPerRow(ind)+jj
+	       elementConn(count8+4)=base+totalnodes2d+j
+	       elementConn(count8+5)=base+totalnodes2d+j+1
+	       elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+jj+1
+	       elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+jj
+	       jj=jj+1
+	     endif
+	     count1=count1+1
+	     count8=count8+8
+           enddo
+           ! last one in the row, wrap around
+           elementIds(count1)=startid+count1
+	   elementConn(count8)= base+j
+	   elementConn(count8+1)=base+1
+	   elementConn(count8+2)=base+numPerRow(ind)+1
+	   elementConn(count8+3)=base+numPerRow(ind)+jj
+	   elementConn(count8+4)=base+totalnodes2d+j
+	   elementConn(count8+5)=base+totalnodes2d+1
+	   elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+1
+	   elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+jj
+   	   count1=count1+1
+	   count8=count8+8
+	   if (k==1 .and. (jj /= numPerRow(ind+1))) then
+	      print *, PetNo, 'Upper row index mismatch', ind, jj, numPerRow(ind+1)
+           endif
+        else  ! diff < 0 
+          ! make triangles with base at upper row
+          ! triangles will be evenly distributed
+	  interval = real(numPerRow(ind+1))/(-1*diff+1)
+	  jj=1
+	  trigs=1
+          do j=1,numPerRow(ind+1)-1
+	     if (j > trigs*interval) then
+	       trigs = trigs+1              
+               ! triangles - base at bottom
+               elementIds(count1)=startid+count1
+	       elementConn(count8)= base+jj
+	       elementConn(count8+1)=base+jj
+	       elementConn(count8+2)=base+numPerRow(ind)+j+1
+	       elementConn(count8+3)=base+numPerRow(ind)+j
+	       elementConn(count8+4)=base+totalnodes2d+jj
+	       elementConn(count8+5)=base+totalnodes2d+jj
+	       elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+j+1
+	       elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+j
+             else
+               elementIds(count1)=startid+count1
+	       elementConn(count8)= base+jj
+	       elementConn(count8+1)=base+jj+1
+	       elementConn(count8+2)=base+numPerRow(ind)+j+1
+	       elementConn(count8+3)=base+numPerRow(ind)+j
+	       elementConn(count8+4)=base+totalnodes2d+jj
+	       elementConn(count8+5)=base+totalnodes2d+jj+1
+	       elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+j+1
+	       elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+j
+	       jj=jj+1
+	     endif
+	     count1=count1+1
+ 	     count8=count8+8
+           enddo
+           ! last one in the row, wrap around
+       	   elementIds(count1)=startid+count1
+	   elementConn(count8)= base+jj
+	   elementConn(count8+1)=base+1
+	   elementConn(count8+2)=base+numPerRow(ind)+1
+	   elementConn(count8+3)=base+numPerRow(ind)+j
+	   elementConn(count8+4)=base+totalnodes2d+jj
+	   elementConn(count8+5)=base+totalnodes2d+1
+	   elementConn(count8+6)=base+numPerRow(ind)+totalnodes2d+1
+	   elementConn(count8+7)=base+numPerRow(ind)+totalnodes2d+j
+ 	   count1=count1+1
+	   count8=count8+8
+	   if (k==1 .and. (jj /= numPerRow(ind))) then
+	      print *, PetNo, 'Lower row index mismatch', ind, jj, numPerRow(ind)
+           endif
+        endif
+       endif         	            
+    enddo
+  enddo 
+
+  if (count1-1 /= totalelements) then
+     print *, 'total element mismatch ', count1-1, totalelements
+  endif
+
+  do i=1, totalelements*8
+     if (elementConn(i) > totalnodes) then
+          print *, PetNo, 'node id out of bound', i/8, elementConn(i)
+     endif
+  enddo  
+  print *, PetNo, "Before MeshAddElements"
+  call ESMF_MeshAddElements(wamMesh, elementIds, elementTypes, elementConn,rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+   print *, PetNo, "After MeshAddElements"
+
+  deallocate(NumPerRow, ShuffleOrder, rowinds, petTable)
+  deallocate(indList, baseind)
+  deallocate(elementIds, elementTypes, elementConn)
+
+#if 0
+  ! Info passed to the run routine
+  is%wrap%wamdims = wamdims
+  is%wrap%wamhgt => wamhgt
+  is%wrap%startlevel = startlevel
+  is%wrap%totallevels = totallevels
+  is%wrap%wamtotalnodes = totalnodes
+  is%wrap%localnodes = localnodes
+  is%wrap%startnode = startnode
+  is%wrap%wam2dMesh = wam2dMesh
+  is%wrap%wamMesh = wamMesh
+  is%wrap%PetNo = PetNo
+  is%wrap%PetCnt = PetCnt
+#endif
+
+  return 
+#else
+    call ESMF_LogSetError(ESMF_RC_LIB_NOT_PRESENT, & 
+                 msg="- ESMF_NETCDF not defined when lib was compiled") 
+    return
+#endif
+
+contains
+
+  subroutine convert2Cart (lon, lat, hgt, coords, rc)
+    real(ESMF_KIND_R8):: lon, lat, hgt
+    real(ESMF_KIND_R8):: coords(3)
+    integer, optional :: rc
+
+    real(ESMF_KIND_R8) :: earthradius, nhgt
+    integer :: localrc
+
+    if (present(rc)) rc=ESMF_FAILURE
+    earthradius = 6371.0
+    nhgt = 1+hgt/earthradius
+
+    coords(1)=lon
+    coords(2)=lat
+    coords(3)=nhgt
+
+    if (present(rc)) rc=ESMF_SUCCESS
+
+  end subroutine convert2Cart
+!
+!  check CDF file error code
+!
+#undef  ESMF_METHOD
+#define ESMF_METHOD "CheckNCError"
+  subroutine CheckNCError (ncStatus, errmsg)
+
+    integer,          intent(in)  :: ncStatus
+    character(len=*), intent(in)  :: errmsg
+
+    integer, parameter :: nf90_noerror = 0
+
+#ifdef ESMF_NETCDF
+    if ( ncStatus .ne. nf90_noerror) then
+      print '("NetCDF Error: ", A, " : ", A)', &
+                trim(errmsg),trim(nf90_strerror(ncStatus))
+      call ESMF_LogSetError(ESMF_RC_NETCDF_ERROR, &
+        msg=trim(errmsg) // " : " // trim(nf90_strerror(ncStatus)), &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return ! bail out
+    end if
+#else
+    call ESMF_LogSetError(ESMF_RC_LIB_NOT_PRESENT, &
+                 msg="- ESMF_NETCDF not defined when lib was compiled")
+    return
+#endif
+
+  end subroutine CheckNCError
+
+end subroutine initGrids
+
+
+end module module_MED_SWPC_methods

--- a/NEMS/src/module_MEDIATOR_SWPC_methods.F90
+++ b/NEMS/src/module_MEDIATOR_SWPC_methods.F90
@@ -2961,7 +2961,7 @@ contains
     
   end subroutine PolyInterpolate
 
-#if 1
+#if 0
   subroutine LogInterpolate(xs, ys, xd, yd, rt, rc)
     ! -- note: both xs and xd are assumed to be "normalized" heights
     ! --       x = 1 + z / earthRadius

--- a/NEMS/src/module_MEDIATOR_SWPC_methods.F90
+++ b/NEMS/src/module_MEDIATOR_SWPC_methods.F90
@@ -2961,7 +2961,7 @@ contains
     
   end subroutine PolyInterpolate
 
-#if 0
+#if 1
   subroutine LogInterpolate(xs, ys, xd, yd, rt, rc)
     ! -- note: both xs and xd are assumed to be "normalized" heights
     ! --       x = 1 + z / earthRadius
@@ -2994,7 +2994,6 @@ contains
       x = xd(i)
       y = 0._ESMF_KIND_R8
       call locate(xs, np, x, j)
-        np, xs(1), xs(np), j, x, i, nd
       if (j == np) then
         itop = i
         exit
@@ -3026,7 +3025,6 @@ contains
       do i = itop, nd
         y = fact * (x1-xd(i)) / (x1*x1+xd(i)*xd(i))
         yd(i) = y1 * exp(y)
-        i, x1, y1, xd(i), yd(i), fact, rt
         x1 = xd(i)
         y1 = yd(i)
       end do

--- a/NEMS/src/module_MEDIATOR_SpaceWeather.F90
+++ b/NEMS/src/module_MEDIATOR_SpaceWeather.F90
@@ -752,7 +752,7 @@ module module_MEDSpaceWeather
   real(ESMF_KIND_R8) :: lon, lat, hgt, lon1, lat1, hgt1
   real(ESMF_KIND_R4) :: interval
   integer :: i,j, k, l, ii, jj, kk, count1, count3, count8, localcount, countup, save, base, base1
-  logical :: even
+  logical :: even, isInd
   integer :: start, count, diff, lastlat, totalelements, totalnodes, localnodes, startid
   integer :: wamtotalnodes
   integer :: elmtcount, increment
@@ -1049,7 +1049,9 @@ module module_MEDSpaceWeather
      ! If the neighbor is local, no need to add
      if (ind < wamdims(2)) then
        if (PetCnt>1) then
-        if ((i < myrows .and. rowinds(i+1) /= ind+1) .or. i==myrows) then
+        isInd = (i < myrows)
+        if (isInd) isInd = (rowinds(i+1) /= ind+1)
+        if (isInd .or. i==myrows) then
           totalnodes=totalnodes+numPerRow(ind)+numPerRow(ind+1)
         else
           totalnodes=totalnodes+numPerRow(ind)
@@ -1107,7 +1109,9 @@ module module_MEDSpaceWeather
        ! if not the last row, add the neighbor row's nodes and the neighbor
        ! is not local
        if (ind < wamdims(2)) then
-         if (i==myrows .or. (i < myrows .and. rowinds(i+1)/= ind+1)) then
+         isInd = (i < myrows)
+         if (isInd) isInd = (rowinds(i+1) /= ind+1)
+         if (isInd .or. i==myrows) then
        	  do j=1, numPerRow(ind+1)
             ! Global id based on the 3D indices
             nodeIds(count1)= j+wamdims(1)*ind+wamdims(1)*wamdims(2)*(k-1)

--- a/NEMS/src/module_MEDIATOR_SpaceWeather.F90
+++ b/NEMS/src/module_MEDIATOR_SpaceWeather.F90
@@ -1815,7 +1815,6 @@ subroutine RunRegrid(model, importState, exportState, rc)
         enddo
         endif
 
-#define NEW_WAY_VECTOR
 #ifdef NEW_WAY_VECTOR
         ! If these are winds, then just save results to be handled later 
         if (trim(fieldNameList(j)) .eq. "northward_wind_neutral") then

--- a/modulefiles/theia/wam-ipe
+++ b/modulefiles/theia/wam-ipe
@@ -2,5 +2,6 @@
 
 # This script is responsible for loading modules that are compatible with
 # the ESMF 7.0.0 API.
-
-  module load intel/16.1.150 impi netcdf esmf/7.0.2
+#
+  module use /scratch3/NCEPDEV/swpc/noscrub/Raffaele.Montuoro/dev/swmed/opt/modulefiles/
+  module load intel impi netcdf esmf/7.1.0dev

--- a/oldcompsets/swpc%20130316_1hr_swpc_gsm%wam%T62_ipe%80x170
+++ b/oldcompsets/swpc%20130316_1hr_swpc_gsm%wam%T62_ipe%80x170
@@ -1,0 +1,74 @@
+###############################################################################
+#
+#  WAM-IPE coupled run
+#
+###############################################################################
+
+export TEST_DESCR="WAM-IPE 1h coupled run"
+
+# - gsm configuration ---
+export_gsm
+export CDATE=2013031600
+export WLCLK=30
+export QUEUE=debug
+export NHRS=1
+export FHOUT=1
+export FHZER=1
+export FHRES=1
+export TASKS=40
+export PE1=32
+export THRD=1
+export QUILT=.false.
+export FDFI=0
+export CP2=.false.
+export IDEA=.true.
+export IDVC=3
+export THERMODYN_ID=3
+export SFCPRESS_ID=2
+export SPECTRALLOOP=2
+
+# - nems.configure ---
+export_nems
+export nems_configure=med_atm_ipm
+export atm_model=gsm
+export atm_petlist_bounds="0 15" # 16
+export ipm_model=ipe
+export ipm_petlist_bounds="16 31" # 16
+export ipm_petlayout="2 8"
+export med_model=swpc
+export med_petlist_bounds="32 39" # 8
+export coupling_interval_fast_sec=180.0
+export coupling_interval_sec=180.0
+
+export F107_KP_SIZE=4800 # 600 days
+export F107_KP_INTERVAL=10800
+export WAM_IPE_COUPLING=.true.
+export HEIGHT_DEPENDENT_G=.true.
+export F107_KP_SKIP_SIZE=0
+
+# Set restart directory
+export RESDIR=/scratch3/NCEPDEV/swpc/noscrub/${USER}/restart_directory/
+
+# - component specific setup calls ---
+# WAM
+setup_wam_T62_2013031600
+
+# IPE
+export IPE_IC_DATE=2013160300
+export IPE_IC_GRID=grid_80x170
+new_setup_ipe
+
+# Mediator
+setup_spaceweather_gsm%wam%T62_ipe%80x170
+
+# -
+RUN_SCRIPT=rt_gfs.sh
+
+# - validation
+export CNTL_DIR=swpc%20130316_1hr_spacewx_gsm%wam%T62_ipe%80x170_V0003
+export LIST_FILES="IPE.inp SMSnamelist \
+                   sigf00 sigf01 sfcf00 sfcf01 flxf00 flxf01 \
+                   plasma00 plasma01 plasma02 plasma03 plasma04 \
+                   plasma05 plasma06 plasma07 plasma08 plasma09 \
+                   plasma10 plasma11 plasma12 plasma13 plasma14 \
+                   plasma15 plasma16"

--- a/scripts/compsets/config/coupled.config
+++ b/scripts/compsets/config/coupled.config
@@ -5,6 +5,7 @@ export IDEA=.true. # just in case the user sets this to false thinking it's for 
 export atm_petlist_bounds=${atm_petlist_bounds:-"0 $((NPROCWAM-1))"} # should be set from wam.config
 export ipm_petlist_bounds=${ipm_petlist_bounds:-"$((NPROCWAM)) $((NPROCWAM+NPROCIPE-1))"}
 export med_petlist_bounds=${med_petlist_bounds:-"$((NPROCWAM+NPROCIPE)) $((PE1-1))"}
+export med_model=${med_model:-spaceweather} # use old mediator by default
 export coupling_interval_fast_sec=${coupling_interval_fast_sec:-${DELTIM}.0}
 export coupling_interval_sec=${coupling_interval_sec:-${DELTIM}.0}
 

--- a/scripts/compsets/exglobal/exglobal_fcst_nems.sh
+++ b/scripts/compsets/exglobal/exglobal_fcst_nems.sh
@@ -1482,7 +1482,7 @@ EARTH_attributes::
 ::
 
 # MED #
-MED_model:                      spaceweather
+MED_model:                      $med_model
 MED_petlist_bounds:             $med_petlist_bounds
 MED_attributes::
   Verbosity = max

--- a/scripts/compsets/march2013_regression.config
+++ b/scripts/compsets/march2013_regression.config
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+## user/job configuration (must be set here)
+export ACCOUNT=swpc  # computational account
+export QUEUE=debug      # computational queue
+export JOBNAME=march2013_updated_mediator # used to name ptmp (ROTDIR) and stmp (RUNDIR) directories, and the job run name
+export CDATE=2013031600   # initialization date (idate) for atmospheric/surface input (do not include the forecast hour for restarts!)
+
+## note that initial conditions (WAM and IPE) should already exist in ROTDIR and be named appropriately.
+## if you want the scripts to handle setting up the ROTDIR for you, you can define IC_DIR as below.
+## it should contain both siganl/sfcanl valid for CDATE (e.g. s*anl.2017071400),
+## and the appropriate IPE files (e.g. ipe_grid_*_params.$IPEDATETIME).
+export IC_DIR=/scratch3/NCEPDEV/swpc/noscrub/Adam.Kubaryk/ICS/WAM-IPE/$CDATE
+
+export PTMP=/scratch3/NCEPDEV/swpc/scrub/Joseph.Schoonover/ptmp/
+export STMP=/scratch3/NCEPDEV/swpc/scrub/Joseph.Schoonover/stmp/
+
+## additionally, when you move to RESTART=.true., you can define RESTARTDIR if you'd like
+## it to not be in the default $ROTDIR/restart_directory.
+#export RESTARTDIR=/swpc/noscrub/George.Millward/restart_directory
+
+## IPEDATETIME defaults to ${CYEAR}${CMONTH}${CDAY}${CHOUR}00
+## in the event that you are doing a RESTART=.true. run, it will select the matching date-time
+## according to the restart file (+minute 00).
+## if you are not using IPE files valid at CDATE or the restart file time (+minute 00),
+## you can set IPEDATETIME as below.
+#export IPEDATETIME=201704170000
+
+## the scripts will select IPE files from wherever it can: ROTDIR, RESTARTDIR, or -- if defined --
+## it will look in IPE_IC_DIR. by default, if IC_DIR is set, IPE_IC_DIR will automatically be
+## set to the same thing. you can specificy otherwise here.
+#export IPE_IC_DIR=/global/noscrub/Adam.Kubaryk
+
+## general model options (must be set here)
+export IDEA=.true.             # .true. for WAM, .false. for standalone IPE
+export WAM_IPE_COUPLING=.true. # coupled system, only used if IDEA=.true.
+export RESTART=.false.         # .false. coldstart, .true. restart
+
+## specific model configuration options (wam.config/exglobal)
+export DELTIM=180 # model timestep
+
+# WAM atm/sfc options
+export FHMAX=1 # hours to forecast from input files. think of this as a segment length
+export FHRES=1 # hours between writing restart files
+export FHOUT=1 # frequency of standard history file output (hours)
+export FHDFI=0 # half number of hours of digital filter initialization
+# IPE output (ipe.config)
+# IPEFREQ will default to DELTIM if unset but is required to be <=FHMAX and a multiple of DELTIM
+export IPEFREQ=3600 # seconds between IPE output
+
+## computational configuration (compute.config)
+export WALLCLOCK=30:00 # minutes
+export NPROCWAM=16
+# below only used if WAM_IPE_COUPLING=.true.
+export NPROCIPE=80
+export IPEDECOMP="1 80"
+export NPROCMED=8
+
+export med_model=swpc
+
+## namelist settings
+# "compset" will use the OldCompsetRun defaults. otherwise it'll use a
+# blend that leans toward Valery/Houjun's parallel scripts.
+export NAMELIST_VER=compset


### PR DESCRIPTION
This pull request is to merge updated_mediator into development .
The changes brought in by this feature include :
* The new mediator that will eventually be used in two-way coupling
* A new environment variable, med_model, that can be used to toggle between the old mediator and the new mediator ( `med_model = swpc` gives the new mediator and `med_model = spaceweather` gives the old mediator). This variable has been added to the march2013_regression.config and user.config files and defaults to the new mediator.
* To toggle vector regridding on and off, we have removed the explicit #DEFINE NEW_WAY_VECTOR NEMS/src/module_MEDIATOR_Spaceweather.F90, and have opted turn on the CPP Flag -DNEW_WAY_VECTOR in NEMS/src/makefile . For now, this flag is not defined, since vector regridding is not available in the new mediator yet.

Documentation of this feature development was tracked in Issue #70 . We were able to reproduce results (to machine precision) between using the old mediator and the new mediator without vector regridding.

For the reviewer (@akubaryk ), verify that the code compiles using
```
NEMS/NEMSAppBuilder rebuild app=wam-ipe
```
The md5sum of the NEMS.x executable should be
```
md5sum NEMS.x 
ebb35bbfa3933b6661538fbd71b408d0  NEMS.x
```
Check to make sure that you can produce a 1hr run +  restart. 

If you're comfortable with this version of the code,  merge this branch into development but do not delete the branch.