### PR TITLE
Merge in feature for calculating MUF-3000

### DIFF
--- a/IPELIB/scripts/Convert_mpi.batch
+++ b/IPELIB/scripts/Convert_mpi.batch
@@ -25,7 +25,7 @@ rm -rf tmp*
 
 # Build the i2hg executable
 module purge
-module load intel/15.6.233 impi/5.0.3.048 netcdf-hdf5parallel
+module load intel/15.6.233 impi/5.0.3.048 netcdf
 make --directory=${WAMIPEDIR}/IPELIB/src/plot/ i2hg_mpi -f i2hg_mpi.mak
 export I2HG_EXE=${WAMIPEDIR}/IPELIB/bin/i2hg_mpi
 

--- a/IPELIB/scripts/Convert_mpi.batch
+++ b/IPELIB/scripts/Convert_mpi.batch
@@ -79,7 +79,7 @@ if [ x\$PBS_O_WORKDIR != x ]; then
    cd \$PBS_O_WORKDIR
 fi
 module purge
-module load intel/15.6.233 impi/5.0.3.048 netcdf-hdf5parallel
+module load intel/15.6.233 impi/5.0.3.048 netcdf
 
 # Run the executable
 ulimit -s unlimited

--- a/IPELIB/src/plot/IPEToHeightGrid_mpi.f90
+++ b/IPELIB/src/plot/IPEToHeightGrid_mpi.f90
@@ -385,7 +385,7 @@ CONTAINS
    INTEGER,DIMENSION(:  ), ALLOCATABLE :: JMIN_IN, JMAX_IS, JMIN_ING, JMAX_ISG
    INTEGER ierr, MaxFluxTube
    CHARACTER( LEN(TRIM(plasmaFile)) ) :: shortenedFile
-   CHARACTER( 12 )                    :: timeStamp
+   CHARACTER( 2 )                     :: timeStamp
 
 
  
@@ -428,8 +428,8 @@ CONTAINS
 
 
       shortenedFile = TRIM(plasmaFile)
-      timestamp     = shortenedFile( LEN(shortenedFile)-11:LEN(shortenedFile) )
-      WRITE( GMTHour, '(I2)' ) timestamp(9:10)
+      timestamp     = shortenedFile( LEN(shortenedFile)-3:LEN(shortenedFile)-2 )
+      READ( timestamp, '(I2)' ) GMTHour
 
      OPEN(UNIT   = 20, &
           FILE   = TRIM(plasmaFile),&
@@ -653,8 +653,11 @@ CONTAINS
       ! Uses approximation of foF2 and foE as a function of time as in
       ! Bradley and Dudeny, "A simple model of the vertical distribution of 
       !  electron concentration in the ionosphere", JATP, 1973
-      localTime = GMTHour - (1.0/15.0)*x(m)
-      dM    = 6*sin( (3.141592653/12.0)*(localTime-5.0) )
+      localTime = GMTHour + x(m)/15.0
+      IF( localTime > 24.0 ) THEN
+        localTime = localTime - 24.0
+      ENDIF
+      dM    = 0.6*sin( (3.141592653/12.0)*(localTime-5.0) )
       m3000 = 1490.0/(hmf2(m,l) + 176.0)-dM
 
       muf3000(m,l) = m3000*sqrt( nmf2(m,l) )/(1.11355287*10.0**5)
@@ -905,6 +908,7 @@ CONTAINS
       CALL Check( nf90_put_var( ncid, tec_varid, total_electron_content ) )
       CALL Check( nf90_put_var( ncid, nmf2_varid, nmf2 ) )
       CALL Check( nf90_put_var( ncid, hmf2_varid, hmf2 ) )
+      CALL Check( nf90_put_var( ncid, muf_varid, muf3000 ) )
       CALL Check( nf90_put_var( ncid, tn_varid, tn_fixed ) )
       CALL Check( nf90_put_var( ncid, u_varid, vn_fixed(:,:,:,1) ) )
       CALL Check( nf90_put_var( ncid, v_varid, vn_fixed(:,:,:,2) ) )

--- a/IPELIB/src/plot/IPEToHeightGrid_mpi.f90
+++ b/IPELIB/src/plot/IPEToHeightGrid_mpi.f90
@@ -31,6 +31,8 @@ USE netcdf
   REAL(kind=real_prec8),DIMENSION(nheights)  :: z
   REAL(kind=real_prec8),DIMENSION(nlon) :: x
   REAL(kind=real_prec8),DIMENSION(nlat) :: y 
+  REAL(kind=real_prec8) :: localtime, dm, m3000
+  INTEGER :: GMTHour
   INTEGER :: height_km
   INTEGER :: i, iheight, iup, ido, ih, ip
   INTEGER :: l, m, mp, lp, in1, in2
@@ -73,6 +75,7 @@ USE netcdf
   REAL(kind=real_prec8),DIMENSION(:,:), ALLOCATABLE     :: total_electron_content
   REAL(kind=real_prec8),DIMENSION(:,:), ALLOCATABLE     :: hmf2
   REAL(kind=real_prec8),DIMENSION(:,:), ALLOCATABLE     :: nmf2
+  REAL(kind=real_prec8),DIMENSION(:,:), ALLOCATABLE     :: muf3000
   REAL(kind=real_prec8),DIMENSION(3)                    :: oplus_interpolated
   REAL(kind=real_prec8),DIMENSION(3)                    :: hplus_interpolated
   REAL(kind=real_prec8),DIMENSION(3)                    :: heplus_interpolated
@@ -325,7 +328,7 @@ CONTAINS
                  electron_density_fixed(nlon,nlat,nheights), &
                  electron_density_fixed_300km(nlon,nlat), &
                  total_electron_content(nlon,nlat), &
-                 hmf2(nlon,nlat), nmf2(nlon,nlat) )
+                 hmf2(nlon,nlat), nmf2(nlon,nlat), muf3000(nlon,nlat) )
             
 
  END SUBROUTINE AllocateArrays
@@ -366,7 +369,7 @@ CONTAINS
                    electron_density_fixed, &
                    electron_density_fixed_300km, &
                    total_electron_content, &
-                   hmf2, nmf2 )
+                   hmf2, nmf2, muf3000 )
               
 
  END SUBROUTINE CleanupArrays
@@ -381,6 +384,10 @@ CONTAINS
    INTEGER,DIMENSION(:,:), ALLOCATABLE :: JMIN_IN_ALL, JMAX_IS_ALL
    INTEGER,DIMENSION(:  ), ALLOCATABLE :: JMIN_IN, JMAX_IS, JMIN_ING, JMAX_ISG
    INTEGER ierr, MaxFluxTube
+   CHARACTER( LEN(TRIM(plasmaFile)) ) :: shortenedFile
+   CHARACTER( 12 )                    :: timeStamp
+
+
  
     allocate(JMIN_IN_ALL(NMP,NLP),JMAX_IS_ALL(NMP,NLP),JMIN_IN(NLP),JMAX_IS(NLP),JMIN_ING(NLP),JMAX_ISG(NLP))
     if ( my_pe .eq. 0 ) then
@@ -419,6 +426,10 @@ CONTAINS
               n2n_ms1(MaxFluxTube,NLP,NMP), &
               o2n_m3(MaxFluxTube,NLP,NMP) )
 
+
+      shortenedFile = TRIM(plasmaFile)
+      timestamp     = shortenedFile( LEN(shortenedFile)-11:LEN(shortenedFile) )
+      WRITE( GMTHour, '(I2)' ) timestamp(9:10)
 
      OPEN(UNIT   = 20, &
           FILE   = TRIM(plasmaFile),&
@@ -638,10 +649,21 @@ CONTAINS
       hmf2(m,l) = (0.0 - b) / (2*c)
       nmf2(m,l) = a + (b*hmf2(m,l)) + (c*hmf2(m,l)*hmf2(m,l))
 
+      ! MUF-3000 
+      ! Uses approximation of foF2 and foE as a function of time as in
+      ! Bradley and Dudeny, "A simple model of the vertical distribution of 
+      !  electron concentration in the ionosphere", JATP, 1973
+      localTime = GMTHour - (1.0/15.0)*x(m)
+      dM    = 6*sin( (3.141592653/12.0)*(localTime-5.0) )
+      m3000 = 1490.0/(hmf2(m,l) + 176.0)-dM
+
+      muf3000(m,l) = m3000*sqrt( nmf2(m,l) )/(1.11355287*10.0**5)
     
+
     ENDDO
   ENDDO
 
+ 
  END SUBROUTINE InterpolateOntoFixedHeightGrid
 !
  SUBROUTINE WriteToNetCDF(  )
@@ -653,7 +675,7 @@ CONTAINS
    INTEGER :: x_varid, y_varid, z_varid, time_varid
    INTEGER :: oplus_varid, hplus_varid, heplus_varid
    INTEGER :: nplus_varid, noplus_varid, o2plus_varid
-   INTEGER :: n2plus_varid, tec_varid, nmf2_varid, hmf2_varid
+   INTEGER :: n2plus_varid, tec_varid, nmf2_varid, hmf2_varid, muf_varid
    INTEGER :: edens_varid
    INTEGER :: tn_varid, u_varid, v_varid, w_varid, on_varid, n2n_varid, o2n_varid
 
@@ -800,6 +822,14 @@ CONTAINS
       CALL Check( nf90_put_att( ncid, hmf2_varid, "_FillValue",fillValue) )
       CALL Check( nf90_put_att( ncid, hmf2_varid,"coordinates", "latitude longitude" ) )
          
+      CALL Check( nf90_def_var( ncid, "muf3000", NF90_PREC,&
+                               (/ x_dimid, y_dimid, time_dimid /),&
+                               muf_varid ) )
+      CALL Check( nf90_put_att( ncid, muf_varid, &
+                                "long_name","Maximum Usable Frequency." ) )
+      CALL Check( nf90_put_att( ncid, muf_varid, "units","[unknown]" ) )
+      CALL Check( nf90_put_att( ncid, muf_varid, "_FillValue",fillValue) )
+      CALL Check( nf90_put_att( ncid, muf_varid,"coordinates", "latitude longitude" ) )
 
       CALL Check( nf90_def_var( ncid, "tn", NF90_PREC,&
                                (/ x_dimid, y_dimid, z_dimid, time_dimid /),&


### PR DESCRIPTION
The muf_3000_product branch contains source code in the IPEToHeightGrid_mpi.f90 post-processor for calculating the maximum usable frequency using a method suggested by Mihail Codriescu at SWPC.

 After inserting this code, I generated MUF from the IPE initial conditions for the March 6, 2013 configuration. Mihail confirms that the calculations were implemented correctly.

In the process of adding this feature, I found that the netcdf-hdf5-parallel module led to segmentation faults when calling netcdf routines. Swapping that module with netcdf appropriate for the intel compiler used eliminated this problem. This led to the changes in the Convert_mpi.batch script used for running the post-processor.