### PR TITLE
Standalone build fix

### DIFF
--- a/NEMS/src/chem/gocart/src/Config/ESMA_arch.mk
+++ b/NEMS/src/chem/gocart/src/Config/ESMA_arch.mk
@@ -101,7 +101,7 @@ ifeq ($(ARCH),Linux)
   SITE := $(patsubst g2%,wcoss,$(SITE))
   SITE := $(patsubst ga%,gaea,$(SITE))
   SITE := $(patsubst tf%,theia,$(SITE))
-echo SITE= ${SITE}
+#echo SITE= ${SITE}
 
 #
 #                    Linux Site Specific

--- a/modulefiles/theia/ESMF_700_gsm
+++ b/modulefiles/theia/ESMF_700_gsm
@@ -3,6 +3,7 @@
 # This script is responsible for loading modules that are compatible with
 # the ESMF 7.0.0 API.
 
-# This script is responsible for loading modules for GSM build with ESMF v7
+#
+  module use /scratch3/NCEPDEV/swpc/noscrub/Raffaele.Montuoro/dev/swmed/opt/modulefiles/
+  module load intel impi netcdf esmf/7.1.0dev
 
- module load intel/16.1.150 impi netcdf/4.3.0 szip esmf/7.0.2


### PR DESCRIPTION
This pull request is to merge standalone_build_fix into development.

The changes brought in by this feature include :
* Modifications to the build system

Since this only changes the build system and standalone WAM does not actually interface with the mediator at any point, for this pull request I just need a review from somebody who is able to check out a fresh copy of the code and test that ./NEMS/NEMSAppBuilder rebuild app=standaloneGSM works.