### PR TITLE
Fixing bug to address standalone restart failure

### DIFF
--- a/scripts/compsets/exglobal/exglobal_fcst_nems.sh
+++ b/scripts/compsets/exglobal/exglobal_fcst_nems.sh
@@ -951,7 +951,7 @@ if [[ $ENS_NUM -le 1 ]] ; then
       ln -fs $GRDI  grid_ini
       ln -fs $GRDI2 grid_ini2
       ln -fs $SIGI2 sig_ini2
-      if [ $WAM_IPE_COUPLING ];then
+      if [ $WAM_IPE_COUPLING = .true. ];then
         export RESTART_AND_COUPLED=.true.
         ln -fs $RSTR  WAM_IPE_RST_rd
       fi
@@ -967,7 +967,7 @@ if [[ $ENS_NUM -le 1 ]] ; then
     ln -fs $NSTI  nst_ini
     ln -fs $PLASI ipe_grid_plasma_params
     ln -fs $NEUTI ipe_grid_neutral_params
-    if [ $WAM_IPE_COUPLING ];then
+    if [ $WAM_IPE_COUPLING = .true. ];then
       export RESTART_AND_COUPLED=.true.
       ln -fs $RSTR  WAM_IPE_RST_rd
     fi


### PR DESCRIPTION
Standalone WAM fails to run in restart mode because the logic checks in exglobal_fcst_nems.sh fail to check $WAM_IPE_COUPLING correctly. As a result, the model tries to read WAM_IPE_RST_rd when it is empty. This single commit changes both of the logic checks to [ $WAM_IPE_COUPLING = .true. ] which bash can interpret correctly.

If we need to test this out explicitly, the quickest way would be to use an existing NEMS.x from development, alter any user.config-type file to `export WAM_IPE_COUPLING=.false.`, and then `./submit.sh user.config 1 2` -- it will submit a cold start and then restart, and produce appropriate output.