### PR TITLE
Theia Build Fix

### DIFF
--- a/NEMS/src/atmos/gsm/phys/makefile
+++ b/NEMS/src/atmos/gsm/phys/makefile
@@ -2,7 +2,7 @@ include ../../../conf/configure.nems
 
 MAKEFILE = makefile
 
-UTILINCS = -I../../share -I../libutil -I../../phys -I../dyn $(GOCARTINCS) -I/scratch3/NCEPDEV/nwprod/lib/sigio/v2.0.1/incmod/sigio_v2.0.1_4
+UTILINCS = -I../../share -I../libutil -I../../phys -I../dyn $(GOCARTINCS)
 ARCH=$(shell uname -s)
 GOCARTINCS = -I../../../chem/gocart/${ARCH}/include/Chem_Base \
              -I../../../chem/gocart/${ARCH}/include/GMAO_mpeu \

--- a/conf/configure.nems.Theia.intel
+++ b/conf/configure.nems.Theia.intel
@@ -16,36 +16,28 @@ include         $(TOP)/conf/configure.nems.NUOPC
 NETCDF_INC   = -I$(NETCDF)/include
 NETCDF_LIB   = -L$(NETCDF)/lib -lnetcdf
 
-LIBDIR=/scratch4/NCEPDEV/meso/noscrub/Ratko.Vasic/libs
 PARADIR=/contrib/nceplibs_ext/lib
 POSTDIR=/scratch2/portfolios/NCEPDEV/global/save/Shrinivas.Moorthi/nceppost_moorthi/sorc/ncep_post.fd
 
-NEMSIO_INC   = -I${LIBDIR}/incmod/nemsio
-NEMSIO_LIB   = -L${LIBDIR} -lnemsio
-
-BACIO_LIB    = -L${LIBDIR} -lbacio_4
-W3_LIB       = -L${LIBDIR} -lw3nco_d -lw3emc_d
-SP_LIB       = -L${LIBDIR} -lsp_d
-SYS_LIB      =
- 
 EXTLIBS      = $(NEMSIO_LIB) \
-               $(BACIO_LIB) \
-               $(W3_LIB) \
-               $(SP_LIB) \
+               $(BACIO_LIB4) \
+               $(W3NCO_LIBd) \
+               $(W3EMC_LIBd) \
+               $(SP_LIBd) \
                $(NETCDF_LIB) \
                $(ESMF_LIB) \
-               $(SYS_LIB)
+               $(SIGIO_LIB4)
 
 ## for the post quilting option
 POSTMOD     = ${POSTDIR}/incmod/post_4
 POST_INC    = -I${POSTDIR}/incmod/post_4
 POST_LIB    = -L${POSTDIR} -lnceppost
-W3_POST_LIB = -L${LIBDIR}  -lw3nco_4 -lw3emc_4
+W3_POST_LIB = ${W3NCO_LIBd} ${W3EMC_LIBd}
 CRTM_LIB    = -L${PARADIR} -lcrtm
-G2_LIB      =  -L${LIBDIR} -lg2tmpl -lg2_4  -L${PARADIR} -ljasper -lpng -lz
+G2_LIB      =  ${G2_LIB4} ${JASPER_LIB} ${PNG_LIB} ${Z_LIB}
 XML_LIB     = -L${PARADIR} -lxmlparse
-SIGIO_LIB   = -L${LIBDIR} -lsigio_4
-SFCIO_LIB   = -L${LIBDIR} -lsfcio
+SIGIO_LIB   = ${SIGIO_LIB4}
+SFCIO_LIB   = ${SFCIO_LIB4}
 
 EXTLIBS_POST = $(NEMSIO_LIB) \
                $(POST_LIB) \
@@ -67,7 +59,7 @@ FREE         = -free
 FIXED        = -fixed
 R8           = -r8
 
-FINCS        = $(ESMF_INC) $(NEMSIO_INC) $(NETCDF_INC)
+FINCS        = $(ESMF_INC) -I$(NEMSIO_INC) $(NETCDF_INC) -I${SIGIO_INC4}
 #TRAPS        =
 #TRAPS        = -g -fno-inline -no-ip -traceback -ftrapuv -fpe0 -ftz -check all -check noarg_temp_created -fp-stack-check
 

--- a/conf/configure.nems.Theia.intel_gsm
+++ b/conf/configure.nems.Theia.intel_gsm
@@ -5,7 +5,6 @@
 
 SHELL           = /bin/sh
 
-include /scratch4/NCEPDEV/meso/noscrub/Ratko.Vasic/libs/esmf_6/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk
 ESMF_INC    = $(ESMF_F90COMPILEPATHS)
 ESMF_LIB    = $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 
@@ -20,40 +19,28 @@ include         $(TOP)/conf/configure.nems.NUOPC
 NETCDF_INC   = -I$(NETCDF)/include
 NETCDF_LIB   = -L$(NETCDF)/lib -lnetcdff -lnetcdf
 
-# LIBDIR=/scratch3/NCEPDEV/nwprod/lib
-LIBDIR=/scratch4/NCEPDEV/meso/noscrub/Ratko.Vasic/libs
 PARADIR=/contrib/nceplibs_ext/lib
 POSTDIR=/scratch4/NCEPDEV/global/save/Shrinivas.Moorthi/nceppost_moorthi/sorc/ncep_post.fd
 
-NEMSIO_INC   = -I${LIBDIR}/incmod/nemsio
-NEMSIO_LIB   = -L${LIBDIR} -lnemsio
-
-BACIO_LIB    = -L${LIBDIR} -lbacio_4
-W3_LIB       = -L${LIBDIR} -lw3nco_d -lw3emc_d
-SP_LIB       = -L${LIBDIR} -lsp_d
-SYS_LIB      =
- 
 EXTLIBS      = $(NEMSIO_LIB) \
-               $(BACIO_LIB) \
-               $(W3_LIB) \
-               $(SP_LIB) \
+               $(BACIO_LIB4) \
+               $(W3NCO_LIBd) \
+               $(W3EMC_LIBd) \
+               $(SP_LIBd) \
                $(NETCDF_LIB) \
                $(ESMF_LIB) \
-               $(SYS_LIB)  
+               $(SIGIO_LIB4)
 
 ## for the post quilting option
 POSTMOD     = ${POSTDIR}/incmod/post_4
 POST_INC    = -I${POSTDIR}/incmod/post_4
 POST_LIB    = -L${POSTDIR} -lnceppost
-W3_POST_LIB = -L${LIBDIR}  -lw3nco_4 -lw3emc_4
-CRTM_LIB    = -L/home/Weiyu.Yang/bin -lcrtm
-# CRTM_LIB    = -L${PARADIR} -lcrtm
-G2_LIB      =  -L$/home/Weiyu.Yang/bin -lg2tmpl -lg2_4  -L${PARADIR} -ljasper -lpng -lz
-# G2_LIB      =  -L${LIBDIR} -lg2tmpl -lg2_4  -L${PARADIR} -ljasper -lpng -lz
-XML_LIB     = -L/home/Weiyu.Yang/bin -lxmlparse
-# XML_LIB     = -L${PARADIR} -lxmlparse
-SIGIO_LIB   = -L${LIBDIR} -lsigio_4
-SFCIO_LIB   = -L${LIBDIR} -lsfcio_4
+W3_POST_LIB = ${W3NCO_LIBd} ${W3EMC_LIBd}
+CRTM_LIB    = -L${PARADIR} -lcrtm
+G2_LIB      =  ${G2_LIB4} ${JASPER_LIB} ${PNG_LIB} ${Z_LIB}
+XML_LIB     = -L${PARADIR} -lxmlparse
+SIGIO_LIB   = ${SIGIO_LIB4}
+SFCIO_LIB   = ${SFCIO_LIB4}
 
 EXTLIBS_POST = $(NEMSIO_LIB) \
                $(POST_LIB) \
@@ -75,7 +62,7 @@ FREE         = -free
 FIXED        = -fixed
 R8           = -r8
 
-FINCS        = $(ESMF_INC) $(NEMSIO_INC) $(NETCDF_INC)
+FINCS        = $(ESMF_INC) -I$(NEMSIO_INC) $(NETCDF_INC) -I$(SIGIO_INC4)
 #  the first one is the default one
    TRAPS        = -g -traceback
 #1 TRAPS        = -g -fno-inline -no-ip -traceback -ftrapuv -fpe0 -ftz -check all -debug all -check noarg_temp_created -fp-stack-check

--- a/modulefiles/theia/ESMF_700_gsm
+++ b/modulefiles/theia/ESMF_700_gsm
@@ -4,7 +4,7 @@
 # the ESMF 7.0.0 API.
 
 #
-  module use /scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles
+  module use -a /scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles
   module use -a /scratch3/NCEPDEV/nwprod/lib/modulefiles
   module load intel impi/5.1.1.109 netcdf
   module load esmf/7.1.0r

--- a/modulefiles/theia/ESMF_700_gsm
+++ b/modulefiles/theia/ESMF_700_gsm
@@ -4,6 +4,13 @@
 # the ESMF 7.0.0 API.
 
 #
-  module use /scratch3/NCEPDEV/swpc/noscrub/Raffaele.Montuoro/dev/swmed/opt/modulefiles/
-  module load intel impi netcdf esmf/7.1.0dev
-
+  module use /scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles
+  module use -a /scratch3/NCEPDEV/nwprod/lib/modulefiles
+  module load intel impi/5.1.1.109 netcdf
+  module load esmf/7.1.0r
+  module load bacio/v2.0.1
+  module load sp/v2.0.2
+  module load w3nco/v2.0.6
+  module load w3emc/v2.0.5
+  module load nemsio/v2.2.3
+  module load sigio/v2.0.1

--- a/modulefiles/theia/wam-ipe
+++ b/modulefiles/theia/wam-ipe
@@ -4,5 +4,12 @@
 # the ESMF 7.0.0 API.
 
 #
-  module use /scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles/
+  module use -a /scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles/
+  module use -a /scratch3/NCEPDEV/nwprod/lib/modulefiles
   module load intel impi/5.1.1.109 netcdf esmf/7.1.0r
+  module load bacio/v2.0.1
+  module load sp/v2.0.2
+  module load w3nco/v2.0.6
+  module load w3emc/v2.0.5
+  module load nemsio/v2.2.3
+  module load sigio/v2.0.1


### PR DESCRIPTION
Previously we had used a hard path to the library directory of a user in the meso group on Theia. That directory does not exist anymore, and no soft-link has been provided, so I took the opportunity to abstract the lib/incmod pathing into the module load, as is done with FV3.

There was also a hardpath in NEMS/src/atmos/gsm/phys/makefile for the sigio incmod folder; that has also been abstracted to the module load.

This should be more flexible overall... in theory, we could use the configure.nems.Theia.intel[_gsm] files on other systems if we accordingly updated the modulefiles and the selection of the conf files in NEMSAppBuilder, but that is probably unnecessary for now.

I also updated the standaloneGSM file to use the same ESMF module as wam-ipe.

Just need somebody to test fresh builds of standaloneGSM and wam-ipe on Theia. These changes need to be backported to our older tags, or they won't build anymore; I don't know the best way to go about doing that.